### PR TITLE
Add description for DeadSkullzJr's usrcheat.dat in Universal Updater

### DIFF
--- a/pages/_en-US/twilightmenu/faq.md
+++ b/pages/_en-US/twilightmenu/faq.md
@@ -30,7 +30,10 @@ Go into TWLMenu++ Settings, and disable `Update recently played list`.
 - If it worked before, delete the `fatTable` and `patchOffsetCache` folders in `sd:/_nds/nds-bootstrap/`
 
 #### How do I use cheats?
-You need to have a cheat DB in the form of a `usrcheat.dat` file in the `sd:/_nds/TWiLightMenu/extras/` folder. The most updated cheat database is [DeadSkullzJr's](https://gbatemp.net/threads/deadskullzjrs-flashcart-cheat-databases.488711/). Alternatively, you can use [r4cce](http://hp.vector.co.jp/authors/VA013928/soft_en.html) to create your own cheat DB.
+You need to have a cheat DB in the form of a `usrcheat.dat` file in the `sd:/_nds/TWiLightMenu/extras/` folder. The most updated cheat database is [DeadSkullzJr's](https://gbatemp.net/threads/deadskullzjrs-flashcart-cheat-databases.488711/). 
+- On the 3DS, this database is available in the Universal Updater app as "NDS Cheat Databases." This will automatically install it to the required location.
+
+Alternatively, you can use [r4cce](http://hp.vector.co.jp/authors/VA013928/soft_en.html) to create your own cheat DB.
 
 #### How do I show a custom picture on the top screen of the DSi theme?
 A random `.png` image in `sd:/_nds/TWiLightMenu/dsimenu/photos/` will be shown each time the menu is loaded.


### PR DESCRIPTION
This explains an easier method for 3DS consoles to download DeadSkullzJr's cheat database to use with TWiLight Menu++. It should avoid confusion for people using a 3DS family console.