### PR TITLE
RAM dump button combo and RAM Viewer controls

### DIFF
--- a/pages/_en-US/twilightmenu/controls.md
+++ b/pages/_en-US/twilightmenu/controls.md
@@ -36,8 +36,29 @@ description: Controls for using TWiLight Menu++
       - <kbd class="l">L</kbd>: Disable all cheats
 
 #### DS ROMs (using nds-bootstrap)
-- <kbd class="l">L</kbd> + <kbd>Down</kbd> + <kbd>SELECT</kbd>: Open the in-game menu
 - <kbd class="l">L</kbd> + <kbd class="r">R</kbd> + <kbd>Up</kbd> + <kbd class="face">X</kbd> for 1 second: Swap the screens
+- <kbd class="l">L</kbd> + <kbd class="r">R</kbd> + <kbd>Down</kbd> + <kbd class="face">A</kbd> for 3 seconds: Dump RAM to `sd:/_nds/nds-bootstrap`, as `ramDump.bin`
+- <kbd class="l">L</kbd> + <kbd>Down</kbd> + <kbd>SELECT</kbd>: Open the in-game menu
+   - RAM Viewer
+      - <kbd>Up</kbd> / <kbd>Down</kbd>: Scroll
+      - <kbd>Left</kbd> / <kbd>Right</kbd>: Fast scroll
+      - <kbd class="face">A</kbd>: Enter RAM Editor
+      - <kbd class="face">B</kbd>: Return to in-game menu
+      - <kbd class="face">Y</kbd>: Specify an address to jump to
+        - <kbd>Up</kbd> / <kbd>Down</kbd>: Increase / Decrease selected value
+        - <kbd>Left</kbd> / <kbd>Right</kbd>: Select a value
+        - <kbd class="face">A</kbd> / <kbd class="face">B</kbd>: Return to RAM Viewer/Editor at specified address
+   - RAM Editor
+      - <kbd>Up</kbd> / <kbd>Down</kbd> / <kbd>Left</kbd> / <kbd>Right</kbd>: Select a value
+      - <kbd class="face">A</kbd>: Modify selected value
+         - <kbd>Up</kbd> / <kbd>Down</kbd>: Increase / Decrease value by 1h
+         - <kbd>Left</kbd> / <kbd>Right</kbd>: Increase / Decrease value by 10h
+         - <kbd class="face">A</kbd> / <kbd class="face">B</kbd>: Finish modifying value
+      - <kbd class="face">B</kbd>: Return to RAM Viewer
+      - <kbd class="face">Y</kbd>: Specify an address to jump to
+        - <kbd>Up</kbd> / <kbd>Down</kbd>: Increase / Decrease selected value
+        - <kbd>Left</kbd> / <kbd>Right</kbd>: Select a value
+        - <kbd class="face">A</kbd> / <kbd class="face">B</kbd>: Return to RAM Viewer/Editor at specified address
 
 #### Boot shortcuts
 These should be pressed on the TWiLight Menu++ splash screen / right after the Nintendo DSi splash screen.


### PR DESCRIPTION
A ~~few~~ list of things to consider changing:

- *RAM Editor* and *RAM Viewer* are referred to as if they are two separate modes, but it would be more accurate to imply a *view mode* and *edit mode* as they both technically are within the RAM Viewer option in the in-game menu. I did not do this, because then view mode would have to be a sub-bullet of RAM Viewer itself along with edit mode, making it more messy (line 42, 51)
- The other two shortcuts are above the in-game menu because of how long and detailed the in-game menu portion is, so it looks nicer this way (line 39, 40)
- The RAM dump shortcut appears to take 3 seconds, but maybe I miscounted 2 as 3? (line 40)
- There's no explanation for `h` (line 54, 55)
- Explanation for address jump function is redundant, because there isn't really a nice way of saying "see above" and it might not make sense to separate it from the viewer and editor portions (line 47, 58)
- This only covers the RAM Viewer functions because everything else in the in-game menu is fairly straightforward, but perhaps those other things would belong on the nds-bootstrap section of the wiki
- *Fast scroll* may not be appropriate (line 44)
- *1h* may be unnecessary, but was done to be consistent with *10h* (line 54, 55)
- Address jumping section makes no mention of hexadecimal, in contrast to value modification (line 48, 59; 54, 55)