### PR TITLE
Refactor hiyaCFW Troubleshooting page to FAQ & Troubleshooting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
+
+gem "webrick", "~> 1.7"

--- a/pages/_en-US/hiyacfw/faq.md
+++ b/pages/_en-US/hiyacfw/faq.md
@@ -32,5 +32,5 @@ There is also a limit of 200 blocks (25MB) for DSiWare in the `00030004` folder.
 
 ##### Invalid title
 There are several things you need to take into account when adding titles to hiyaCFW:
-  - Game card dumps cannot be run without being using a [forwarder](forwarders)
-  - Homebrew need to be built correctly using modern tools to work from the Nintendo DSi Menu
+- Game card dumps cannot be run without being using a [forwarder](forwarders)
+- Homebrew need to be built correctly using modern tools to work from the Nintendo DSi Menu

--- a/pages/_en-US/hiyacfw/troubleshooting.md
+++ b/pages/_en-US/hiyacfw/troubleshooting.md
@@ -17,20 +17,20 @@ If your Nintendo DSi shows an error in this format when booting, with the # bein
 #### "An error has occurred"
 When the Nintendo DSi Menu detects a problem it will usually show this generic error message, some of the causes are:
 
-  - The free space bug
-    - The Nintendo DSi Menu has a bug when checking the free space on large storage devices. While this can't occur on the actual NAND (since the chip is only 256 MiB), it can happen when using an SD card.
+##### The free space bug
+The Nintendo DSi Menu has a bug when checking the free space on large storage devices. While this can't occur on the actual NAND (since the chip is only 256 MiB), it can happen when using an SD card.
 
-    - What works and what doesn't goes by every other range of two gibibytes. For example, having 0-2 GiB of free space works, but 2-4 GiB doesn't. The same goes for 4-6 GiB vs 6-8 GiB, up until you get to the size of your SD card.
+What works and what doesn't goes by every other range of two gibibytes. For example, having 0-2 GiB of free space works, but 2-4 GiB doesn't. The same goes for 4-6 GiB vs 6-8 GiB, up until you get to the size of your SD card.
 
-    - The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/DS-Homebrew/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
+The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/DS-Homebrew/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
 
-  - Over 39 titles
-    - The Nintendo DSi Menu has a limit of 39 titles. If you have more than that, delete some from the folders in `sd:/title` or use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to uninstall them.
+##### Over 39 titles
+The Nintendo DSi Menu has a limit of 39 titles. If you have more than that, delete some from the folders in `sd:/title` or use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to uninstall them.
 
-  - Too much space used by DSiWare
-    - There is also a limit of 200 blocks (25MB) for DSiWare in the `00030004` folder. This can be worked around by installing as system apps using [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest).
+##### Too much space used by DSiWare
+There is also a limit of 200 blocks (25MB) for DSiWare in the `00030004` folder. This can be worked around by installing as system apps using [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest).
 
-  - Invalid title
-    - There are several things you need to take into account when adding titles to hiyaCFW:
-    - Game card dumps cannot be run without being using a [forwarder](forwarders)
-    - Homebrew need to be built correctly using modern tools to work from the Nintendo DSi Menu
+##### Invalid title
+There are several things you need to take into account when adding titles to hiyaCFW:
+  - Game card dumps cannot be run without being using a [forwarder](forwarders)
+  - Homebrew need to be built correctly using modern tools to work from the Nintendo DSi Menu

--- a/pages/_en-US/hiyacfw/troubleshooting.md
+++ b/pages/_en-US/hiyacfw/troubleshooting.md
@@ -1,16 +1,20 @@
 ---
 lang: en-US
-layout: wiki
+layout: faq
 section: hiyacfw
-title: Troubleshooting
+title: FAQ & Troubleshooting
+long_title: hiyaCFW FAQ & Troubleshooting
 category: other
-description: Troubleshooting information for hiyaCFW
+description: FAQ & Troubleshooting for hiyaCFW
 ---
 
-### #-2435-8325
+#### How do I install apps to hiyaCFW's SDNAND?
+You will need to use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to install any apps to the SDNAND.
+
+#### #-2435-8325
 If your Nintendo DSi shows an error in this format when booting, with the # being a number, that means that bootstage 2 thinks something is wrong with your SDNAND. This is usually fixed by [reinstalling hiyaCFW](installing).
 
-### "An error has occurred"
+#### "An error has occurred"
 When the Nintendo DSi Menu detects a problem it will usually show this generic error message, some of the causes are:
 
 #### The free space bug

--- a/pages/_en-US/hiyacfw/troubleshooting.md
+++ b/pages/_en-US/hiyacfw/troubleshooting.md
@@ -22,7 +22,7 @@ The Nintendo DSi Menu has a bug when checking the free space on large storage de
 
 What works and what doesn't goes by every other range of two gibibytes. For example, having 0-2 GiB of free space works, but 2-4 GiB doesn't. The same goes for 4-6 GiB vs 6-8 GiB, up until you get to the size of your SD card.
 
-The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/DS-Homebrew/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
+The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/RocketRobz/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
 
 ##### Over 39 titles
 The Nintendo DSi Menu has a limit of 39 titles. If you have more than that, delete some from the folders in `sd:/title` or use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to uninstall them.

--- a/pages/_en-US/hiyacfw/troubleshooting.md
+++ b/pages/_en-US/hiyacfw/troubleshooting.md
@@ -8,7 +8,7 @@ description: Troubleshooting information for hiyaCFW
 ---
 
 ### #-2435-8325
-If your Nintendo DSi shows an error in this format when booting, with the # being a number, that means that bootstage 2 thinks something is wrong with your SDNAND. This is usually fixed by [reinstalling hiyaCFW](installing-hiyacfw).
+If your Nintendo DSi shows an error in this format when booting, with the # being a number, that means that bootstage 2 thinks something is wrong with your SDNAND. This is usually fixed by [reinstalling hiyaCFW](installing).
 
 ### "An error has occurred"
 When the Nintendo DSi Menu detects a problem it will usually show this generic error message, some of the causes are:
@@ -18,7 +18,7 @@ The Nintendo DSi Menu has a bug when checking the free space on large storage de
 
 What works and what doesn't goes by every other range of two gibibytes. For example, having 0-2 GiB of free space works, but 2-4 GiB doesn't. The same goes for 4-6 GiB vs 6-8 GiB, up until you get to the size of your SD card.
 
-The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/RocketRobz/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
+The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/DS-Homebrew/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
 
 #### Over 39 titles
 The Nintendo DSi Menu has a limit of 39 titles. If you have more than that, delete some from the folders in `sd:/title` or use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to uninstall them.

--- a/pages/_en-US/hiyacfw/troubleshooting.md
+++ b/pages/_en-US/hiyacfw/troubleshooting.md
@@ -17,20 +17,20 @@ If your Nintendo DSi shows an error in this format when booting, with the # bein
 #### "An error has occurred"
 When the Nintendo DSi Menu detects a problem it will usually show this generic error message, some of the causes are:
 
-#### The free space bug
-The Nintendo DSi Menu has a bug when checking the free space on large storage devices. While this can't occur on the actual NAND (since the chip is only 256 MiB), it can happen when using an SD card.
+  - The free space bug
+    - The Nintendo DSi Menu has a bug when checking the free space on large storage devices. While this can't occur on the actual NAND (since the chip is only 256 MiB), it can happen when using an SD card.
 
-What works and what doesn't goes by every other range of two gibibytes. For example, having 0-2 GiB of free space works, but 2-4 GiB doesn't. The same goes for 4-6 GiB vs 6-8 GiB, up until you get to the size of your SD card.
+    - What works and what doesn't goes by every other range of two gibibytes. For example, having 0-2 GiB of free space works, but 2-4 GiB doesn't. The same goes for 4-6 GiB vs 6-8 GiB, up until you get to the size of your SD card.
 
-The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/DS-Homebrew/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
+    - The latest hiyaCFW version can create dummy files to work around this, so make sure that you download the latest version of [hiyaCFW](https://github.com/DS-Homebrew/hiyaCFW/releases/latest/download/hiyaCFW.7z) and copy `hiya.dsi` from "for SDNAND SD card" to the root of your SD card.
 
-#### Over 39 titles
-The Nintendo DSi Menu has a limit of 39 titles. If you have more than that, delete some from the folders in `sd:/title` or use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to uninstall them.
+  - Over 39 titles
+    - The Nintendo DSi Menu has a limit of 39 titles. If you have more than that, delete some from the folders in `sd:/title` or use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to uninstall them.
 
-#### Too much space used by DSiWare
-There is also a limit of 200 blocks (25MB) for DSiWare in the `00030004` folder. This can be worked around by installing as system apps using [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest).
+  - Too much space used by DSiWare
+    - There is also a limit of 200 blocks (25MB) for DSiWare in the `00030004` folder. This can be worked around by installing as system apps using [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest).
 
-#### Invalid title
-There are several things you need to take into account when adding titles to hiyaCFW:
-- Game card dumps cannot be run without being using a [forwarder](forwarders)
-- Homebrew need to be built correctly using modern tools to work from the Nintendo DSi Menu
+  - Invalid title
+    - There are several things you need to take into account when adding titles to hiyaCFW:
+    - Game card dumps cannot be run without being using a [forwarder](forwarders)
+    - Homebrew need to be built correctly using modern tools to work from the Nintendo DSi Menu

--- a/pages/_en-US/hiyacfw/troubleshooting.md
+++ b/pages/_en-US/hiyacfw/troubleshooting.md
@@ -11,10 +11,10 @@ description: FAQ & Troubleshooting for hiyaCFW
 #### How do I install apps to hiyaCFW's SDNAND?
 You will need to use [TMFH](https://github.com/JeffRuLz/TMFH/releases/latest) to install any apps to the SDNAND.
 
-#### #-2435-8325
+#### Why do I get the #-2435-8325 error code?
 If your Nintendo DSi shows an error in this format when booting, with the # being a number, that means that bootstage 2 thinks something is wrong with your SDNAND. This is usually fixed by [reinstalling hiyaCFW](installing).
 
-#### "An error has occurred"
+#### Why do I get "An error has occurred" message when booting hiyaCFW?
 When the Nintendo DSi Menu detects a problem it will usually show this generic error message, some of the causes are:
 
 ##### The free space bug


### PR DESCRIPTION
**This PR:**
- adds "webrick" to Gemfile to allow building on Ruby 3 just in case
- converts hiyaCFW Troubleshooting page to FAQ & Troubleshooting page, in line with all other project FAQ pages
- adds a FAQ (how to install things to SDNAND)



