### PR TITLE
hiyaCFW uninstalling page & others

### DIFF
--- a/pages/_en-US/ds-index/wifi.md
+++ b/pages/_en-US/ds-index/wifi.md
@@ -22,7 +22,7 @@ An Android mobile hotspot set to Open (none) security would also work.
 Windows cannot create a compatible hotspot, so Windows users will need to boot into Linux in order to set one up.
 #### Other methods
 If you cannot create a DS-compatible hotspot using the above methods, you may be able to use another method.
-- [Nintendo Wi-Fi USB Connector](https://gbatemp.net/threads/575631/)
+- Nintendo Wi-Fi USB Connector
   - While this can still be used, it is not recommended because it requires a 32-bit version of Windows XP or Vista
   - For information on setting up a Nintendo Wi-Fi USB Connector, read Section 3 of this [Wiimmfi Guide](https://docs.google.com/document/d/1f3PChwQig40UaiPXlh-Gi5CggGiBPzyrpiecLZlT8ZE/edit?usp=sharing) written by members of the [Mario Kart DS Network](https://discord.gg/pa9bea6)
 - Changing router settings to be DS-compatible

--- a/pages/_en-US/gbarunner2/faq.md
+++ b/pages/_en-US/gbarunner2/faq.md
@@ -20,3 +20,6 @@ Not right now. Instead, you can permanently inject cheat codes into your GBA ROM
 
 #### How do I use Wi-Fi link features?
 You will need a build from the [wifi_link](https://github.com/Gericom/GBARunner2/tree/wifi_link) branch to use the features. You can find detailed instructions on how to setup the builds on its [GBAtemp Wiki page](https://wiki.gbatemp.net/wiki/GBARunner2/Link).
+
+#### Why isn't RTC (Real Time Clock) supported in a ROM hack?
+RTC is supported on a per-game basis. You will need to change the ROM's game code to that of the original game so that GBARunner2 will recognize it.

--- a/pages/_en-US/gbarunner2/faq.md
+++ b/pages/_en-US/gbarunner2/faq.md
@@ -22,4 +22,4 @@ Not right now. Instead, you can permanently inject cheat codes into your GBA ROM
 You will need a build from the [wifi_link](https://github.com/Gericom/GBARunner2/tree/wifi_link) branch to use the features. You can find detailed instructions on how to setup the builds on its [GBAtemp Wiki page](https://wiki.gbatemp.net/wiki/GBARunner2/Link).
 
 #### Why isn't RTC (Real Time Clock) supported in a ROM hack?
-RTC is supported on a per-game basis. You will need to change the ROM's game code to that of the original game so that GBARunner2 will recognize it.
+RTC is supported on a per-game basis. You will have to change the ROM's game code to that of the original game so that GBARunner2 will recognize it.

--- a/pages/_en-US/hiyacfw/uninstalling.md
+++ b/pages/_en-US/hiyacfw/uninstalling.md
@@ -7,12 +7,12 @@ long_title: Uninstalling hiyaCFW
 description: How to uninstall hiyaCFW from Nintendo DSi
 ---
 
-hiyaCFW is only present on the SD card and has no presence on your NAND. Before proceeding, be sure to backup any save data from your SDNAND that you wish to keep. You can learn how to do that by following Section III of the [DSiWare Backups](https://dsi.cfw.guide/dsiware-backups.html#section-iii---extracting-the-save-file-optional) guide.
+hiyaCFW is only present on the SD card and has no presence on your NAND. Before proceeding, be sure to backup any save data from your SDNAND that you wish to keep. You can learn how to do that by following Section III of the [dsi.cfw.guide](https://dsi.cfw.guide)'s [DSiWare Backups](https://dsi.cfw.guide/dsiware-backups.html#section-iii---extracting-the-save-file-optional) guide.
 
 ### Uninstalling
 1. Delete `hiya.dsi` from the SD card root
 1. Delete the `hiya` folder
-1. Delete the folders titled `import`, `photo`, `progress`, `shared1`, `shared2`, `sys`, `title`, `ticket`, and `tmp`
+1. Delete the `import`, `photo`, `progress`, `shared1`, `shared2`, `sys`, `title`, `ticket`, and `tmp` folders
 
 ### Changing Unlaunch settings
 
@@ -20,6 +20,7 @@ If you had set Unlaunch to autoboot hiyaCFW, you may want to change these settin
 
 1. Insert your SD card into your Nintendo DSi and start the console while holding <kbd class="face">A</kbd> and <kbd class="face">B</kbd>
    - This will open the Unlaunch Filemenu
-1. Go to `OPTIONS`, and set `AUTOBOOT` to your desired application
+1. Go to `OPTIONS`, and set `NO BUTTON` to your desired application
    - If you wish to autoboot the system NAND, set it to the application named `Launcher`
+   - If you wish to autoboot TWiLight Menu++, choose the file named `BOOT.NDS`
 1. Choose `SAVE & EXIT`

--- a/pages/_en-US/hiyacfw/uninstalling.md
+++ b/pages/_en-US/hiyacfw/uninstalling.md
@@ -1,0 +1,25 @@
+---
+lang: en-US
+layout: wiki
+section: hiyacfw
+title: Uninstalling
+long_title: Uninstalling hiyaCFW
+description: How to uninstall hiyaCFW from Nintendo DSi
+---
+
+hiyaCFW is only present on the SD card and has no presence on your NAND. Before proceeding, be sure to backup any save data from your SDNAND that you wish to keep. You can learn how to do that by following Section III of the [DSiWare Backups](https://dsi.cfw.guide/dsiware-backups.html#section-iii---extracting-the-save-file-optional) guide.
+
+### Uninstalling
+1. Delete `hiya.dsi` from the SD card root
+1. Delete the `hiya` folder
+1. Delete the folders titled `import`, `photo`, `progress`, `shared1`, `shared2`, `sys`, `title`, `ticket`, and `tmp`
+
+### Changing Unlaunch settings
+
+If you had set Unlaunch to autoboot hiyaCFW, you may want to change these settings now that you no longer use it.
+
+1. Insert your SD card into your Nintendo DSi and start the console while holding <kbd class="face">A</kbd> and <kbd class="face">B</kbd>
+   - This will open the Unlaunch Filemenu
+1. Go to `OPTIONS`, and set `AUTOBOOT` to your desired application
+   - If you wish to autoboot the system NAND, set it to the application named `Launcher`
+1. Choose `SAVE & EXIT`

--- a/pages/_en-US/nds-bootstrap/faq.md
+++ b/pages/_en-US/nds-bootstrap/faq.md
@@ -60,3 +60,7 @@ The reason screenshots can only be taken of the main screen is a hardware limita
 
 #### What is the "VRAM bank" I'm asked to select when taking a screenshot?
 When taking a screenshot using nds-bootstrap it needs to use the DS's display capture feature to capture a frame from the main engine, however this display capture can only write to VRAM and requires one of the first four banks. nds-bootstrap will try to select a bank that isn't being used for the main engine so usually you can simply ignore this, however in some case all four of the possible VRAM banks will be in use for the main engine and thus it's not possible to take a perfect screenshot and you will need to select the bank you find looks best.
+
+#### Can I play games online using nds-bootstrap?
+Playing games online with nds-bootstrap will work exactly as it does with real Game Cards. See the [Wi-Fi](../ds-index/wifi) page for information on connecting to an alternate online service.
+- If you are playing a DSi-Enhanced game in DS mode, you are restricted to unsecured or WEP network connections

--- a/pages/_en-US/other/godmode9i.md
+++ b/pages/_en-US/other/godmode9i.md
@@ -27,3 +27,10 @@ Editing files on the DSi NAND is not safe and can easily lead to a brick, so God
 
 #### Why can't I view NDS file info for some DSiWare?
 Some DSiWare, specifically those located in the `0003000f` folder, contain system data and do not have a valid banner.
+
+#### Should I use the NDS version or the DSi version? What's the difference?
+These are functionally the same, but they have specific purposes.
+- If you are using GodMode9i with a flashcard, use the NDS version
+- If you are installing GodMode9i to your hiyaCFW SDNAND, use the DSi version
+- If you are starting GodMode9i via TWiLight Menu++, both versions will work identically
+- If you are installing GodMode9i to your 3DS HOME Menu, use the CIA version


### PR DESCRIPTION
- Add a page that explains how to uninstall hiyaCFW
- Remove one of the unnecessary links to a NWFC USB Connector tutorial
- Add information on RTC not working on GBARunner2
  - (needs more information, but I'm not experienced with GBA ROM hacking)
- Add "Can I play games online using nds-bootstrap?" to nds-bootstrap FAQ
- Add "Should I use the NDS version or the DSi version?" to GM9i FAQ