### PR TITLE
Update nds-bootstrap wiki for 0.54.0

### DIFF
--- a/pages/_en-US/nds-bootstrap/controls.md
+++ b/pages/_en-US/nds-bootstrap/controls.md
@@ -3,14 +3,15 @@ lang: en-US
 layout: wiki
 section: nds-bootstrap
 title: Controls
-long_title: nds-bootstrap controls
+long_title: nds-bootstrap Controls
 description: Button controls for nds-bootstrap
 ---
-
-These do not apply to DSiWare.
+These do not apply to homebrew.
 - <kbd class="l">L</kbd> + <kbd class="r">R</kbd> + <kbd>Up</kbd> + <kbd class="face">X</kbd> for 1 second: Swap the screens
 - <kbd class="l">L</kbd> + <kbd class="r">R</kbd> + <kbd>Down</kbd> + <kbd class="face">A</kbd> for 2 seconds: Dump RAM to `sd:/_nds/nds-bootstrap`, as `ramDump.bin`
 - <kbd class="l">L</kbd> + <kbd class="r">R</kbd> + <kbd>Down</kbd> + <kbd class="face">B</kbd> for 2 seconds: Return to loader
+- <kbd class="l">L</kbd> + <kbd class="r">R</kbd> + <kbd>START</kbd> + <kbd>SELECT</kbd> for 2 seconds: Reset game
+  - Many games support simply pressing this button combination by default, but this will force reset it
 - <kbd class="l">L</kbd> + <kbd>Down</kbd> + <kbd>SELECT</kbd>: Open the in-game menu
    - <kbd class="r">R</kbd>: Advance by one frame
    - Screenshot
@@ -39,7 +40,7 @@ These do not apply to DSiWare.
         - <kbd>Up</kbd>/<kbd>Down</kbd>: Increase/Decrease selected value
         - <kbd>Left</kbd>/<kbd>Right</kbd>: Select a value
         - <kbd class="face">A</kbd>/<kbd class="face">B</kbd>: Return to RAM Viewer/Editor at specified address
-- Returning to loader may not work on some O3DS models, and does not work in B4DS mode
+- Returning to loader may not work on some O3DS models, and does not work in B4DS mode or when used as a button combination in DSiWare
 - The button combination for opening the in-game menu can be changed in the TWiLight Menu++ settings
 - Screenshots are saved to `sd:/_nds/nds-bootstrap/screenshots.tar`. This file can be opened using an archive viewer such as [7-Zip](https://www.7-zip.org/)
-- Dumping RAM and taking screenshots are currently not possible in B4DS mode
+- Taking screenshots is currently not possible in B4DS mode

--- a/pages/_en-US/nds-bootstrap/glossary.md
+++ b/pages/_en-US/nds-bootstrap/glossary.md
@@ -27,9 +27,6 @@ Changes the mode of the Video Random Access Memory (VRAM) of the system. ROMs ra
 ### Card Read DMA
 Enables the uses of Direct Memory Access (DMA) for card reads. Having this setting on can speed up ROMs but may cause issues. More technical info can be found on the [DS Index](https://wiki.ds-homebrew.com/ds-index/retail-roms#card-read-dma).
 
-### SWI Halt Hook
-Changes whether Halt Software Interrupts (SWI) are Hooked or not. Having it set to On can speed up loading times, but might cause issues. Keeping it Off may reduce slowdowns as well.
-
 ### Ex. ROM space in RAM
 If a game is small enough, it can be loaded into the system's RAM to speed up loading times. Turning this option on will increase the size limit for ROMs, but might break some.
 

--- a/pages/_en-US/nds-bootstrap/testing.md
+++ b/pages/_en-US/nds-bootstrap/testing.md
@@ -31,6 +31,6 @@ To view ROMs with known issues, check the [issues page](https://github.com/DS-Ho
 - Also make sure to remove games that have been tested off of the Testing Queue sheet
 
 #### If testing to update blacklists 
-- Change only the blacklisted options, these being: 133 MHz (TWL) CPU Speed, Card Read DMA, Asynch Card Read, and SWI Halt Hook
+- Change only the blacklisted options, these being: 133 MHz (TWL) CPU Speed, Card Read DMA, and Asynch Card Read
 - To enable blacklisted options in the per-game settings, go to `sd:/_nds/TWiLightMenu/settings.ini` and set `IGNORE_BLACKLISTS` to `1`
 - If there are any issues caused when turning on these settings, please report them on the Github issues page 


### PR DESCRIPTION
Controls page:
- Removes exclusion of DSiWare
- Removes exclusion of RAM dumps with B4DS
- Adds mention of returning to loader shortcut not working in DSiWare (https://github.com/DS-Homebrew/nds-bootstrap/issues/1348)
- Also adds holding L + R + START + SELECT to force reset

Removes mentions of SWI Halt Hook on other pages.