### PR TITLE
Update nds-bootstrap FAQ

### DIFF
--- a/pages/_en-US/nds-bootstrap/faq.md
+++ b/pages/_en-US/nds-bootstrap/faq.md
@@ -8,14 +8,15 @@ description: FAQ & Troubleshooting for nds-bootstrap
 ---
 
 #### I'm having issues with my ROM(s), what should I do?
-- Make sure that you are on the latest release of [nds-bootstrap](https://github.com/DS-Homebrew/nds-bootstrap/releases/latest) and [TWiLight Menu++](https://github.com/DS-Homebrew/TWiLightMenu/releases/latest) if you are using it (update instructions are provided in each release page)
+- Make sure that you are on the latest release of [nds-bootstrap](https://github.com/DS-Homebrew/nds-bootstrap/releases/latest) and [**TW**i**L**ight Menu++](https://github.com/DS-Homebrew/TWiLightMenu/releases/latest) if you are using it (update instructions are provided in each release page)
 - Check [the nds-bootstrap compatibility list](https://docs.google.com/spreadsheets/d/1LRTkXOUXraTMjg1eedz_f7b5jiuyMv2x6e_jY_nyHSc/htmlview#gid=0) to see if this is a known issue on the latest version of nds-bootstrap
-- Try with all cheats disabled for that game as some cheats are not compatible with nds-bootstrap at the moment, pressing <kbd class="l">L</kbd> in the game's cheats menu on TWiLight Menu++ will disable all cheats for it
+- Try with all cheats disabled for that game as some cheats are not compatible with nds-bootstrap at the moment, pressing <kbd class="l">L</kbd> in the game's cheats menu on **TW**i**L**ight Menu++ will disable all cheats for it
 - If it worked before, delete the `fatTable` and `patchOffsetCache` folders in `sd:/_nds/nds-bootstrap/`
 - Run the game with different settings, this includes ARM9 CPU Speed, Async card read, DS/DSi Mode, sound quality, Card read DMA, etc
-    - Using TWiLight Menu++, change all the per-game settings to `Default` 
+    - Using **TW**i**L**ight Menu++, change all the per-game settings to `Default` 
     - If there is a specific per-game setting that causes your issue, please report this to the [GitHub repository](https://github.com/DS-Homebrew/nds-bootstrap/issues)
 - If present, delete the cheat database (`usrcheat.dat`) in `sd:/_nds/TWiLightMenu/extras`
+- [Re-dump the ROM](https://wiki.ds-homebrew.com/twilightmenu/faq?faq=how-do-i-get-games) to ensure that it is not corrupted
 - If you have followed all the above steps, ask in the [Discord server](https://discord.gg/yD3spjv)
 - If the server says it's an nds-bootstrap issue, check if the game hasn't been reported already on GitHub 
     - Check the closed issues too in case there has already been an issue closed in preference a different one
@@ -68,6 +69,7 @@ You can get nightly builds for nds-bootstrap [here](https://github.com/TWLBot/Bu
 #### Why do my cheats not work?
 - Some cheats may have button activators or other conditions that need to be met. Check the description of the cheat for more information
   - In **TW**i**L**ight Menu++, you can press Y to view a specific cheat's information, when available
+- Most cheats were developed for use in DS mode and may not work correctly while running in DSi mode. If the game is DSi-Enhanced, try setting it to run in DS mode
 - The way E-type cheats are implemented in nds-bootstrap is currently broken, meaning they may or may not work. Your cheat probably uses that type, and it is not known when this issue will be fixed
 
 For more info on cheats, check the [Action Replay cheats section of the Retail ROMs page](https://wiki.ds-homebrew.com/ds-index/retail-roms#action-replay-cheats).
@@ -93,7 +95,7 @@ Playing games online with nds-bootstrap will work exactly as it does with real G
 
 #### Can setting a game to use 133 MHz (TWL) CPU speed damage my console?
 No. While not all games may function correctly under this setting, the DSi and 3DS were designed to be able to reach this CPU speed.
-- If you encounter an issue with a game when running at 133 MHz (TWL) CPU speed, create an issue on the [TWiLight Menu++ GitHub repository](https://github.com/DS-Homebrew/TWiLightMenu/issues) detailing the effects so that it may be blacklisted from being launched at that CPU speed
+- If you encounter an issue with a game when running at 133 MHz (TWL) CPU speed, create an issue on the [**TW**i**L**ight Menu++ GitHub repository](https://github.com/DS-Homebrew/TWiLightMenu/issues) detailing the effects so that it may be blacklisted from being launched at that CPU speed
 
 #### Can I speed up games using nds-bootstrap?
 While TWL CPU speed may reduce lag, nds-bootstrap cannot run games at faster speeds than intended.
@@ -104,3 +106,10 @@ No. Since nds-bootstrap runs games natively, it cannot change the function of mo
 #### How do I play randomized Pokémon ROMs with nds-bootstrap?
 Pokémon HeartGold/SoulSilver, Black/White, and Black 2 / White 2 have anti-piracy measures that have to be manually patched out *before* randomizing the ROM. You can do this with [DS-Scene ROM Tool](https://gbatemp.net/download/35735/).
 - Randomized ROMs cannot be AP-patched on-the-fly like the vanilla versions of these games are, because randomizing a ROM has far too many unique possible outputs to be reasonably included with **TW**i**L**ight Menu++
+
+#### What are DSi binaries? How do I get them?
+DSi binaries are the portions of a game's code to be used on DSi (as well as 3DS) systems for use of the DSi's features, such as the cameras and improved Wi-Fi capabilities. Older dumping methods may not have properly dumped these.
+
+- ROMs without the DSi binaries can still be played on any console through DS mode, in which case it will run as if the game were being played on a Nintendo DS Phat/Lite
+
+To obtain a ROM that contains the DSi binaries, [re-dump your Game Card](https://wiki.ds-homebrew.com/twilightmenu/faq?faq=how-do-i-get-games).

--- a/pages/_en-US/nds-bootstrap/faq.md
+++ b/pages/_en-US/nds-bootstrap/faq.md
@@ -110,6 +110,6 @@ Pokémon HeartGold/SoulSilver, Black/White, and Black 2 / White 2 have anti-pira
 #### What are DSi binaries? How do I get them?
 DSi binaries are the portions of a game's code to be used on DSi (as well as 3DS) systems for use of the DSi's features, such as the cameras and improved Wi-Fi capabilities. Older dumping methods may not have properly dumped these.
 
-- ROMs without the DSi binaries can still be played on any console through DS mode, in which case it will run as if the game were being played on a Nintendo DS Phat/Lite
+- ROMs without the DSi binaries can still be played on any console through DS mode, in which it will run as if the game were being played on a Nintendo DS Phat/Lite
 
 To obtain a ROM that contains the DSi binaries, [re-dump your Game Card](https://wiki.ds-homebrew.com/twilightmenu/faq?faq=how-do-i-get-games).


### PR DESCRIPTION
- Adds "What are DSi binaries? How do I get them?"
- Adds suggestion of trying DS mode if cheats aren't working in a DSi-Enhanced game
- Adds suggestion of re-dumping the ROM if it's not working