### PR TITLE
Update custom DSi/3DS skins page

### DIFF
--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-sfx.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-sfx.md
@@ -12,17 +12,17 @@ TWiLight Menu++ supports custom sound files in themes. Place your sound files un
 These instructions assume you have devkitPro installed with mmutil. You can get devkitPro at the [devkitPro website](https://devkitpro.org/wiki/Getting_Started).
 
 ## Sound Effect Bank
-The sound effect bank (sfx.bin) contains sound effects such as the icon select sound, etc.
+The sound effect bank (`sfx.bin`) contains sound effects such as the icon select sound, etc.
 
-|File      |Description|
-|----------|-----------|
-|startup.wav|Played on startup. See the section on [Startup sound](#startup-sound) for more details|
-|back.wav  |Back       |
-|launch.wav|Played when launching a game|
-|select.wav|Played when moving the cursor in the per-game settings and select menu|
-|wrong.wav|Played when reaching the end of the page|
-|switch.wav|Played when switching pages|
-|stop.wav|Played on the DSi Theme when the select cursor stops moving|
+|File        |Description                                                                             |
+|------------|----------------------------------------------------------------------------------------|
+|startup.wav | Played on startup. See the section on [Startup sound](#startup-sound) for more details |
+|back.wav    | Back                                                                                   |
+|launch.wav  | Played when launching a game                                                           |
+|select.wav  | Played when moving the cursor in the per-game settings and select menu                 |
+|wrong.wav   | Played when reaching the end of the page                                               |
+|switch.wav  | Played when switching pages                                                            |
+|stop.wav    | Played on the DSi Theme when the select cursor stops moving                            |
 
 All the files listed above are required to build a custom sound effect bank. If you want a sound to be mute, you can use a silent audio file. The `.wav` format is mandatory and the encoding *must* be PCM.
 

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -135,13 +135,15 @@ These must be PNG files. Transparency is supported, however only 100% transparen
 Only used for the 3DS theme, `3dsRotatingCubes.rvid` is a Rocket Video file. For more information on converting videos to rvid, read [Converting a video to .rvid](https://github.com/RocketRobz/Vid2RVID/wiki/Converting-a-video-to-.rvid) on the Vid2RVID wiki. If you don't want this to be drawn you can simply delete it.
 
 ### Volume textures (`volume` folder)
+Volume textures are only displayed in DSi Mode.
+
 These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.
 
 
 | Texture | Description/Notes                |
 | ------- | -------------------------------- |
-| volume0 | Volume is only shown in DSi mode |
-| volume1 | 0 is muted, 4 is full volume     |
+| volume0 | 0 is muted, 4 is full volume     |
+| volume1 |                                  |
 | volume2 |                                  |
 | volume3 |                                  |
 | volume4 |                                  |

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -152,8 +152,8 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 | `StartBorderSpriteW`     | The width of the start border sprite. Note that the start border texture is exactly half of the full border. | 32            | 32            |
 | `StartBorderSpriteH`     | The height of the start border sprite                                                                        | 64            | 80            |
 | `StartTextRenderY`       | The initial Y position of the Start text                                                                     | 143           | 143           |
-| `BubbleTipRenderY`       | The Y position of the tip of the bubble that is drawn over the start border                                  | 98            | 80            |
 | `BubbleTipRenderX`       | The X position of the tip of the bubble that is drawn over the start border                                  | 125           | 122           |
+| `BubbleTipRenderY`       | The Y position of the tip of the bubble that is drawn over the start border                                  | 98            | 80            |
 | `BubbleTipSpriteW`       | The width of the bubble tip sprite                                                                           | 7             | 11            |
 | `BubbleTipSpriteH`       | The height of the bubble tip sprite                                                                          | 7             | 8             |
 | `TitleboxRenderY`        | The initial Y position of the title text box                                                                 | 96            | 85            |
@@ -163,21 +163,44 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 | `TitleboxMaxLines`       | The maximum lines of text to show of the title                                                               | 3             | 4             |
 | `VolumeRenderX`          | The X position on the top screen to draw the volume icon                                                     | 4             | 4             |
 | `VolumeRenderY`          | The Y position on the top screen to draw the volume icon                                                     | 5             | 5             |
-| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172           |
 | `ShoulderLRenderX`       | The X position on the top screen to draw the left shoulder                                                   | 0             | 0             |
-| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172           |
+| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172           |
 | `ShoulderRRenderX`       | The X position on the top screen to draw the right shoulder                                                  | 178           | 178           |
-| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5             |
+| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172           |
 | `BatteryRenderX`         | The X position on the top screen to draw the battery icon                                                    | 235           | 235           |
+| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5             |
+| `UsernameRenderX`        | The X position on the top screen to draw the username text                                                   | 28            | 28            |
+| `UsernameRenderY`        | The Y position on the top screen to draw the username text                                                   | 15            | 15            |
+| `UsernameRenderXDS`      | The X position on the top screen to draw the username text, when on a DS Phat/Lite                           | 4             | 4             |
+| `DateRenderX`            | The X postion on the top screen to draw the date text                                                        | 162           | 162           |
+| `DateRenderY`            | The Y postion on the top screen to draw the date text                                                        | 7             | 7             |
+| `TimeRenderX`            | The X positon on the top screen to draw the time text                                                        | 200           | 200           |
+| `TimeRenderY`            | The Y positon on the top screen to draw the time text                                                        | 7             | 7             |
 | `PurpleBatteryAvailable` | Whether or not to use the purple battery icons when `Power LED color` is set to `Purple` in settings         | 1             | 1             |
 | `FontPalette1`           | The transparent color of the font, unused for default fonts                                                  | 0x0000        | 0x0000        |
 | `FontPalette2`           | The colors of the font, use [this site](http://www.conradshome.com/html2bgr15/) to convert                   | 0xDEF7        | 0xDEF7        |
 | `FontPalette3`           |                                                                                                              | 0xC631        | 0xC631        |
 | `FontPalette4`           |                                                                                                              | 0xA108        | 0xA108        |
-| `FontPaletteDateTime1`   | The transparent color of the font for the date and time                                                      | 0x0000        | 0x0000        |
-| `FontPaletteDateTime2`   | The color of the font for the date and time                                                                  | 0xDEF7        | 0xA529        |
+| `FontPaletteDateTime1`   | The override transparent color of the font for the date and time                                             | 0x0000        | 0x0000        |
+| `FontPaletteDateTime2`   | The override color of the font for the date and time                                                         | 0xDEF7        | 0xA529        |
 | `FontPaletteDateTime3`   |                                                                                                              | 0xC631        | 0xBDEF        |
 | `FontPaletteDateTime4`   |                                                                                                              | 0xA108        | 0xD6B5        |
+| `FontPaletteTitlebox1`   | The override transparent color of the font for the ROM title box                                             | 0x0000        | 0x0000        |
+| `FontPaletteTitlebox2`   | The override color of the font for the ROM title box                                                         | 0xDEF7        | 0xDEF7        |
+| `FontPaletteTitlebox3`   |                                                                                                              | 0xC631        | 0xC631        |
+| `FontPaletteTitlebox4`   |                                                                                                              | 0xA108        | 0xA108        |
+| `FontPaletteDialog1`     | The override transparent color of the font for dialogs                                                       | 0x0000        | 0x0000        |
+| `FontPaletteDialog2`     | The override color of the font for dialogs                                                                   | 0xDEF7        | 0xDEF7        |
+| `FontPaletteDialog3`     |                                                                                                              | 0xC631        | 0xC631        |
+| `FontPaletteDialog4`     |                                                                                                              | 0xA108        | 0xA108        |
+| `FontPaletteOverlay1`    | The override transparent color of the font for overlayed text                                                | 0x0000        | 0x0000        |
+| `FontPaletteOverlay2`    | The override color of the font for overlayed text                                                            | 0xDEF7        | 0xDEF7        |
+| `FontPaletteOverlay3`    |                                                                                                              | 0xC631        | 0xC631        |
+| `FontPaletteOverlay4`    |                                                                                                              | 0xA108        | 0xA108        |
+| `FontPaletteName1`       | The override transparent color of the font for the username                                                  | 0x0000        | 0x0000        |
+| `FontPaletteName2`       | The override color of the font for the username                                                              | 0xDEF7        | 0xDEF7        |
+| `FontPaletteName3`       |                                                                                                              | 0xC631        | 0xC631        |
+| `FontPaletteName4`       |                                                                                                              | 0xA108        | 0xA108        |
 | `StartTextUserPalette`   | Whether to use the DS Profile color for the palette of the start text                                        |               | 1             |
 | `StartBorderUserPalette` | Whether to use the DS Profile color for the palette of the start border                                      |               | 1             |
 | `ButtonArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen         |               | 1             |

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -22,15 +22,17 @@ You can now open whichever image you want to edit in GIMP and continue to the se
 ### Background textures (`background` folder)
 These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
 
-| Texture            | Description                                                                                            |
-| ------------------ | ------------------------------------------------------------------------------------------------------ |
-| bottom             | The bottom background texture when not hovering over an icon                                           |
-| bottom_bubble      | The bottom background texture when hovering over an icon                                               |
-| bottom_ds          | For the 3DS theme, the bottom background texture when not hovering over an icon when on a DS Phat/Lite |
-| bottom_bubble_ds   | For the 3DS theme, the bottom background texture when hovering over an icon when on a DS Phat/Lite     |
-| bottom_bubble_macro| For the DSi theme, the background texture when hovering over an icon using Macro Mode                  |
-| bottom_moving      | For the DSi theme, the bottom background texture when moving an icon
-| top                | The top screen background texture                                                                      |
+| Texture             | Description                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
+| bottom              | The bottom background texture when not hovering over an icon                                           |
+| bottom_ds           | For the 3DS theme, the bottom background texture when not hovering over an icon when on a DS Phat/Lite |
+| bottom_macro        | For the DSi theme, the background texture when not hovering over an icon while using Macro Mode        |
+| bottom_bubble       | The bottom background texture when hovering over an icon                                               |
+| bottom_bubble_ds    | For the 3DS theme, the bottom background texture when hovering over an icon when on a DS Phat/Lite     |
+| bottom_bubble_macro | For the DSi theme, the background texture when hovering over an icon while using Macro Mode            |
+| bottom_moving       | For the DSi theme, the bottom background texture when moving an icon                                   |
+| bottom_moving_macro | For the DSi theme, the background texture when moving an icon while using Maco Mode                    |
+| top                 | The top screen background texture                                                                      |
 
 ### Battery textures (`battery` folder)
 These must be PNG files, any file will work however only 100% transparency will work. Any pixel that is transparent in one icon should be transparent in all of them so that it's properly overwritten on change.
@@ -156,19 +158,18 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 | `BubbleTipSpriteH`       | The height of the bubble tip sprite                                                                          | 7             | 8             |
 | `TitleboxRenderY`        | The initial Y position of the title text box                                                                 | 96            | 85            |
 | `TitleboxTextY`          | The initial Y position of the title text                                                                     | 55            | 30            |
-| `TitleboxTextW`          | The maximum width of the title text                                                                          | 200           | 240            |
-| `MacroTitleboxTextY`     | The initial Y position of the title text in macro mode                                                       |               | 40            |
-| `MacroTitleboxTextW`     | The maximum width of the title text in macro mode                                                            |               | 224            |
-| `TitleboxTextLarge`      | Whether to use the large font for the title text                                                             | 0             | 1              |
-| `TitleboxMaxLines`       | The maximum lines of text to show of the title                                                               | 3             | 4              |
-| `VolumeRenderX`          | The X position on the top screen to draw the volume icon                                                     | 4             | 4              |
-| `VolumeRenderY`          | The Y position on the top screen to draw the volume icon                                                     | 5             | 5              |
-| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172            |
-| `ShoulderLRenderX`       | The X position on the top screen to draw the left shoulder                                                   | 0             | 0              |
-| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172            |
-| `ShoulderRRenderX`       | The X position on the top screen to draw the right shoulder                                                  | 178           | 178            |
-| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5              |
-| `BatteryRenderX`         | The X position on the top screen to draw the battery icon                                                    | 235           | 235            |
+| `TitleboxTextW`          | The maximum width of the title text                                                                          | 200           | 240           |
+| `TitleboxTextLarge`      | Whether to use the large font for the title text                                                             | 0             | 1             |
+| `TitleboxMaxLines`       | The maximum lines of text to show of the title                                                               | 3             | 4             |
+| `VolumeRenderX`          | The X position on the top screen to draw the volume icon                                                     | 4             | 4             |
+| `VolumeRenderY`          | The Y position on the top screen to draw the volume icon                                                     | 5             | 5             |
+| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172           |
+| `ShoulderLRenderX`       | The X position on the top screen to draw the left shoulder                                                   | 0             | 0             |
+| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172           |
+| `ShoulderRRenderX`       | The X position on the top screen to draw the right shoulder                                                  | 178           | 178           |
+| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5             |
+| `BatteryRenderX`         | The X position on the top screen to draw the battery icon                                                    | 235           | 235           |
+| `PurpleBatteryAvailable` | Whether or not to use the purple battery icons when `Power LED color` is set to `Purple` in settings         | 1             | 1             |
 | `FontPalette1`           | The transparent color of the font, unused for default fonts                                                  | 0x0000        | 0x0000        |
 | `FontPalette2`           | The colors of the font, use [this site](http://www.conradshome.com/html2bgr15/) to convert                   | 0xDEF7        | 0xDEF7        |
 | `FontPalette3`           |                                                                                                              | 0xC631        | 0xC631        |
@@ -177,14 +178,17 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 | `FontPaletteDateTime2`   | The color of the font for the date and time                                                                  | 0xDEF7        | 0xA529        |
 | `FontPaletteDateTime3`   |                                                                                                              | 0xC631        | 0xBDEF        |
 | `FontPaletteDateTime4`   |                                                                                                              | 0xA108        | 0xD6B5        |
-| `StartTextUserPalette`   | Whether to use the DS Profile color for the palette of the start text                                        |               | 1              |
-| `StartBorderUserPalette` | Whether to use the DS Profile color for the palette of the start border                                      |               | 1              |
-| `ButtonArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen         |               | 1              |
-| `MovingArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow shown when moving icons                     |               | 1              |
-| `LaunchDotsUserPalette`  | Whether to use the DS Profile color for the palette of the launch dots                                       |               | 1              |
-| `DialogBoxUserPalette`   | Whether to use the DS Profile color for the palette of the dialog box                                        |               | 1              |
-| `RenderPhoto`            | Whether or not to draw a photo on the top screen                                                             | 0             | 1              |
-| `RotatingCubesRenderY`   | The Y position on the top screen to draw the rotating cubes                                                  | 78            |                |
+| `StartTextUserPalette`   | Whether to use the DS Profile color for the palette of the start text                                        |               | 1             |
+| `StartBorderUserPalette` | Whether to use the DS Profile color for the palette of the start border                                      |               | 1             |
+| `ButtonArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen         |               | 1             |
+| `MovingArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow shown when moving icons                     |               | 1             |
+| `LaunchDotsUserPalette`  | Whether to use the DS Profile color for the palette of the launch dots                                       |               | 1             |
+| `DialogBoxUserPalette`   | Whether to use the DS Profile color for the palette of the dialog box                                        |               | 1             |
+| `RenderPhoto`            | Whether or not to draw a photo on the top screen                                                             | 0             | 1             |
+| `RotatingCubesRenderY`   | The Y position on the top screen to draw the rotating cubes                                                  | 78            |               |
+
+### Macro Mode options
+You may add specific override options to `theme.ini` for use in Macro Mode. To do this, add `[MACRO]` to a blank line at the bottom of the configuration file, then add any specified configurations below it.
 
 ## Part 3: Adding to TWiLight Menu++
 Once you've edited some graphics and would like to test your skin, simply copy your skin folder (the folder containing the `background`, `battery`, etc folders) to `sd:/_nds/TWiLightMenu/3dsmenu/themes/` or `sd:/_nds/TWiLightMenu/dsimenu/themes/` for 3DS and DSi theme skins respectively.

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -26,6 +26,7 @@ These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
 
 | Texture             | Description                                                                                            |
 | ------------------- | ------------------------------------------------------------------------------------------------------ |
+| top                 | The top screen background texture                                                                      |
 | bottom              | The bottom background texture when not hovering over an icon                                           |
 | bottom_ds           | For the 3DS theme, the bottom background texture when not hovering over an icon when on a DS Phat/Lite |
 | bottom_macro        | For the DSi theme, the background texture when not hovering over an icon while using Macro Mode        |
@@ -34,7 +35,6 @@ These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
 | bottom_bubble_macro | For the DSi theme, the background texture when hovering over an icon while using Macro Mode            |
 | bottom_moving       | For the DSi theme, the bottom background texture when moving an icon                                   |
 | bottom_moving_macro | For the DSi theme, the background texture when moving an icon while using Maco Mode                    |
-| top                 | The top screen background texture                                                                      |
 
 ### Battery textures (`battery` folder)
 These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -146,69 +146,71 @@ These must be PNG files, any file will work however only 100% transparency will 
 ## Theme configuration (`theme.ini` file)
 You may configure various options on how the theme is drawn in the `theme.ini` to accommodate larger sprites or textures. For true/false options `0` is false and `1` is true. Options with a blank default value for a theme are unused for that theme.
 
-| Value                    | Description                                                                                                  | Default (3DS) | Default (DSi) |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------- | ------------- |
-| `StartBorderRenderY`     | The initial Y position of the Start Border                                                                   | 92            | 81            |
-| `StartBorderSpriteW`     | The width of the start border sprite. Note that the start border texture is exactly half of the full border. | 32            | 32            |
-| `StartBorderSpriteH`     | The height of the start border sprite                                                                        | 64            | 80            |
-| `StartTextRenderY`       | The initial Y position of the Start text                                                                     | 143           | 143           |
-| `BubbleTipRenderX`       | The X position of the tip of the bubble that is drawn over the start border                                  | 125           | 122           |
-| `BubbleTipRenderY`       | The Y position of the tip of the bubble that is drawn over the start border                                  | 98            | 80            |
-| `BubbleTipSpriteW`       | The width of the bubble tip sprite                                                                           | 7             | 11            |
-| `BubbleTipSpriteH`       | The height of the bubble tip sprite                                                                          | 7             | 8             |
-| `TitleboxRenderY`        | The initial Y position of the title text box                                                                 | 96            | 85            |
-| `TitleboxTextY`          | The initial Y position of the title text                                                                     | 55            | 30            |
-| `TitleboxTextW`          | The maximum width of the title text                                                                          | 200           | 240           |
-| `TitleboxTextLarge`      | Whether to use the large font for the title text                                                             | 0             | 1             |
-| `TitleboxMaxLines`       | The maximum lines of text to show of the title                                                               | 3             | 4             |
-| `VolumeRenderX`          | The X position on the top screen to draw the volume icon                                                     | 4             | 4             |
-| `VolumeRenderY`          | The Y position on the top screen to draw the volume icon                                                     | 5             | 5             |
-| `ShoulderLRenderX`       | The X position on the top screen to draw the left shoulder                                                   | 0             | 0             |
-| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172           |
-| `ShoulderRRenderX`       | The X position on the top screen to draw the right shoulder                                                  | 178           | 178           |
-| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172           |
-| `BatteryRenderX`         | The X position on the top screen to draw the battery icon                                                    | 235           | 235           |
-| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5             |
-| `UsernameRenderX`        | The X position on the top screen to draw the username text                                                   | 28            | 28            |
-| `UsernameRenderY`        | The Y position on the top screen to draw the username text                                                   | 15            | 15            |
-| `UsernameRenderXDS`      | The X position on the top screen to draw the username text, when on a DS Phat/Lite                           | 4             | 4             |
-| `DateRenderX`            | The X postion on the top screen to draw the date text                                                        | 162           | 162           |
-| `DateRenderY`            | The Y postion on the top screen to draw the date text                                                        | 7             | 7             |
-| `TimeRenderX`            | The X positon on the top screen to draw the time text                                                        | 200           | 200           |
-| `TimeRenderY`            | The Y positon on the top screen to draw the time text                                                        | 7             | 7             |
-| `PurpleBatteryAvailable` | Whether or not to use the purple battery icons when `Power LED color` is set to `Purple` in settings         | 1             | 1             |
-| `FontPalette1`           | The transparent color of the font, unused for default fonts                                                  | 0x0000        | 0x0000        |
-| `FontPalette2`           | The colors of the font, use [this site](http://www.conradshome.com/html2bgr15/) to convert                   | 0xDEF7        | 0xDEF7        |
-| `FontPalette3`           |                                                                                                              | 0xC631        | 0xC631        |
-| `FontPalette4`           |                                                                                                              | 0xA108        | 0xA108        |
-| `FontPaletteDateTime1`   | The override transparent color of the font for the date and time                                             | 0x0000        | 0x0000        |
-| `FontPaletteDateTime2`   | The override color of the font for the date and time                                                         | 0xDEF7        | 0xA529        |
-| `FontPaletteDateTime3`   |                                                                                                              | 0xC631        | 0xBDEF        |
-| `FontPaletteDateTime4`   |                                                                                                              | 0xA108        | 0xD6B5        |
-| `FontPaletteTitlebox1`   | The override transparent color of the font for the ROM title box                                             | 0x0000        | 0x0000        |
-| `FontPaletteTitlebox2`   | The override color of the font for the ROM title box                                                         | 0xDEF7        | 0xDEF7        |
-| `FontPaletteTitlebox3`   |                                                                                                              | 0xC631        | 0xC631        |
-| `FontPaletteTitlebox4`   |                                                                                                              | 0xA108        | 0xA108        |
-| `FontPaletteDialog1`     | The override transparent color of the font for dialogs                                                       | 0x0000        | 0x0000        |
-| `FontPaletteDialog2`     | The override color of the font for dialogs                                                                   | 0xDEF7        | 0xDEF7        |
-| `FontPaletteDialog3`     |                                                                                                              | 0xC631        | 0xC631        |
-| `FontPaletteDialog4`     |                                                                                                              | 0xA108        | 0xA108        |
-| `FontPaletteOverlay1`    | The override transparent color of the font for overlayed text                                                | 0x0000        | 0x0000        |
-| `FontPaletteOverlay2`    | The override color of the font for overlayed text                                                            | 0xDEF7        | 0xDEF7        |
-| `FontPaletteOverlay3`    |                                                                                                              | 0xC631        | 0xC631        |
-| `FontPaletteOverlay4`    |                                                                                                              | 0xA108        | 0xA108        |
-| `FontPaletteName1`       | The override transparent color of the font for the username                                                  | 0x0000        | 0x0000        |
-| `FontPaletteName2`       | The override color of the font for the username                                                              | 0xDEF7        | 0xDEF7        |
-| `FontPaletteName3`       |                                                                                                              | 0xC631        | 0xC631        |
-| `FontPaletteName4`       |                                                                                                              | 0xA108        | 0xA108        |
-| `StartTextUserPalette`   | Whether to use the DS Profile color for the palette of the start text                                        |               | 1             |
-| `StartBorderUserPalette` | Whether to use the DS Profile color for the palette of the start border                                      |               | 1             |
-| `ButtonArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen         |               | 1             |
-| `MovingArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow shown when moving icons                     |               | 1             |
-| `LaunchDotsUserPalette`  | Whether to use the DS Profile color for the palette of the launch dots                                       |               | 1             |
-| `DialogBoxUserPalette`   | Whether to use the DS Profile color for the palette of the dialog box                                        |               | 1             |
-| `RenderPhoto`            | Whether or not to draw a photo on the top screen                                                             | 0             | 1             |
-| `RotatingCubesRenderY`   | The Y position on the top screen to draw the rotating cubes                                                  | 78            |               |
+| Value                      | Description                                                                                                                     | Default (3DS) | Default (DSi) |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------- |
+| `StartBorderRenderY`       | The initial Y position of the Start Border                                                                                      | 92            | 81            |
+| `StartBorderSpriteW`       | The width of the start border sprite. Note that the start border texture is exactly half of the full border                     | 32            | 32            |
+| `StartBorderSpriteH`       | The height of the start border sprite                                                                                           | 64            | 80            |
+| `StartTextRenderY`         | The initial Y position of the Start text                                                                                        | 143           | 143           |
+| `BubbleTipRenderX`         | The X position of the tip of the bubble that is drawn over the start border                                                     | 125           | 122           |
+| `BubbleTipRenderY`         | The Y position of the tip of the bubble that is drawn over the start border                                                     | 98            | 80            |
+| `BubbleTipSpriteW`         | The width of the bubble tip sprite                                                                                              | 7             | 11            |
+| `BubbleTipSpriteH`         | The height of the bubble tip sprite                                                                                             | 7             | 8             |
+| `TitleboxRenderY`          | The initial Y position of the title text box                                                                                    | 96            | 85            |
+| `TitleboxTextY`            | The initial Y position of the title text                                                                                        | 55            | 30            |
+| `TitleboxTextW`            | The maximum width of the title text                                                                                             | 200           | 240           |
+| `TitleboxTextLarge`        | Whether to use the large font for the title text                                                                                | 0             | 1             |
+| `TitleboxMaxLines`         | The maximum lines of text to show of the title                                                                                  | 3             | 4             |
+| `VolumeRenderX`            | The X position on the top screen to draw the volume icon                                                                        | 4             | 4             |
+| `VolumeRenderY`            | The Y position on the top screen to draw the volume icon                                                                        | 5             | 5             |
+| `ShoulderLRenderX`         | The X position on the top screen to draw the left shoulder                                                                      | 0             | 0             |
+| `ShoulderLRenderY`         | The Y position on the top screen to draw the left shoulder                                                                      | 172           | 172           |
+| `ShoulderRRenderX`         | The X position on the top screen to draw the right shoulder                                                                     | 178           | 178           |
+| `ShoulderRRenderY`         | The Y position on the top screen to draw the right shoulder                                                                     | 172           | 172           |
+| `BatteryRenderX`           | The X position on the top screen to draw the battery icon                                                                       | 235           | 235           |
+| `BatteryRenderY`           | The Y position on the top screen to draw the battery icon                                                                       | 5             | 5             |
+| `UsernameRenderX`          | The X position on the top screen to draw the username text                                                                      | 28            | 28            |
+| `UsernameRenderY`          | The Y position on the top screen to draw the username text                                                                      | 15            | 15            |
+| `UsernameRenderXDS`        | The X position on the top screen to draw the username text, when on a DS Phat/Lite                                              | 4             | 4             |
+| `DateRenderX`              | The X postion on the top screen to draw the date text                                                                           | 162           | 162           |
+| `DateRenderY`              | The Y postion on the top screen to draw the date text                                                                           | 7             | 7             |
+| `TimeRenderX`              | The X positon on the top screen to draw the time text                                                                           | 200           | 200           |
+| `TimeRenderY`              | The Y positon on the top screen to draw the time text                                                                           | 7             | 7             |
+| `PurpleBatteryAvailable`   | Whether or not to use the purple battery icons when `Power LED color` is set to `Purple` in settings                            | 1             | 1             |
+| `FontPalette1`             | The transparent color of the font, unused for default fonts                                                                     | 0x0000        | 0x0000        |
+| `FontPalette2`             | The colors of the font, use [this site](http://www.conradshome.com/html2bgr15/) to convert                                      | 0xDEF7        | 0xDEF7        |
+| `FontPalette3`             |                                                                                                                                 | 0xC631        | 0xC631        |
+| `FontPalette4`             |                                                                                                                                 | 0xA108        | 0xA108        |
+| `FontPaletteDateTime1`     | The override transparent color of the font for the date and time                                                                | 0x0000        | 0x0000        |
+| `FontPaletteDateTime2`     | The override color of the font for the date and time                                                                            | 0xDEF7        | 0xA529        |
+| `FontPaletteDateTime3`     |                                                                                                                                 | 0xC631        | 0xBDEF        |
+| `FontPaletteDateTime4`     |                                                                                                                                 | 0xA108        | 0xD6B5        |
+| `FontPaletteTitlebox1`     | The override transparent color of the font for the ROM title box                                                                | 0x0000        | 0x0000        |
+| `FontPaletteTitlebox2`     | The override color of the font for the ROM title box                                                                            | 0xDEF7        | 0xDEF7        |
+| `FontPaletteTitlebox3`     |                                                                                                                                 | 0xC631        | 0xC631        |
+| `FontPaletteTitlebox4`     |                                                                                                                                 | 0xA108        | 0xA108        |
+| `FontPaletteDialog1`       | The override transparent color of the font for dialogs                                                                          | 0x0000        | 0x0000        |
+| `FontPaletteDialog2`       | The override color of the font for dialogs                                                                                      | 0xDEF7        | 0xDEF7        |
+| `FontPaletteDialog3`       |                                                                                                                                 | 0xC631        | 0xC631        |
+| `FontPaletteDialog4`       |                                                                                                                                 | 0xA108        | 0xA108        |
+| `FontPaletteOverlay1`      | The override transparent color of the font for overlayed text                                                                   | 0x0000        | 0x0000        |
+| `FontPaletteOverlay2`      | The override color of the font for overlayed text                                                                               | 0xDEF7        | 0xDEF7        |
+| `FontPaletteOverlay3`      |                                                                                                                                 | 0xC631        | 0xC631        |
+| `FontPaletteOverlay4`      |                                                                                                                                 | 0xA108        | 0xA108        |
+| `FontPaletteName1`         | The override transparent color of the font for the username                                                                     | 0x0000        | 0x0000        |
+| `FontPaletteName2`         | The override color of the font for the username                                                                                 | 0xDEF7        | 0xDEF7        |
+| `FontPaletteName3`         |                                                                                                                                 | 0xC631        | 0xC631        |
+| `FontPaletteName4`         |                                                                                                                                 | 0xA108        | 0xA108        |
+| `StartTextUserPalette`     | Whether or not to use the DS Profile color for the palette of the start text                                                    |               | 1             |
+| `StartBorderUserPalette`   | Whether or not to use the DS Profile color for the palette of the start border                                                  |               | 1             |
+| `ButtonArrowUserPalette`   | Whether or not to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen                     |               | 1             |
+| `MovingArrowUserPalette`   | Whether or not to use the DS Profile color for the palette of the arrow shown when moving icons                                 |               | 1             |
+| `LaunchDotsUserPalette`    | Whether or not to use the DS Profile color for the palette of the launch dots                                                   |               | 1             |
+| `DialogBoxUserPalette`     | Whether or not to use the DS Profile color for the palette of the dialog box                                                    |               | 1             |
+| `RenderPhoto`              | Whether or not to draw a photo on the top screen                                                                                | 0             | 1             |
+| `RotatingCubesRenderY`     | The Y position on the top screen to draw the rotating cubes                                                                     | 78            |               |
+| `PlayStartupJingle`        | Whether or not to use the startup sound before the main BGM. See the [custom SFX](custom-dsi-3ds-sfx) page for more information | 1             | 0             |
+| `StartupJingleDelayAdjust` | The amount of samples early in the startup sound the BGM should start at                                                        | 0             | 0             |
 
 ### Macro Mode options
 You may add specific override options to `theme.ini` for use in Macro Mode. To do this, add `[MACRO]` to a blank line at the bottom of the configuration file, then add any specified configurations below it.

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -37,7 +37,7 @@ These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
 | bottom_moving_macro | For the DSi theme, the background texture when moving an icon while using Maco Mode                    |
 
 ### Battery textures (`battery` folder)
-These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.
+These must be PNG files. Transparency is supported, however only 100% transparency will work.
 
 | Texture            | Description/Notes                                                           |
 | ------------------ | --------------------------------------------------------------------------- |
@@ -137,7 +137,7 @@ Only used for the 3DS theme, `3dsRotatingCubes.rvid` is a Rocket Video file. For
 ### Volume textures (`volume` folder)
 Volume textures are only displayed in DSi Mode.
 
-These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.
+These must be PNG files. Transparency is supported, however only 100% transparency will work.
 
 
 | Texture | Description/Notes                |
@@ -202,10 +202,10 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 | `FontPaletteOverlay2`      | The override color of the font for overlayed text                                                                               | 0xDEF7        | 0xDEF7        |
 | `FontPaletteOverlay3`      |                                                                                                                                 | 0xC631        | 0xC631        |
 | `FontPaletteOverlay4`      |                                                                                                                                 | 0xA108        | 0xA108        |
-| `FontPaletteName1`         | The override transparent color of the font for the username                                                                     | 0x0000        | 0x0000        |
-| `FontPaletteName2`         | The override color of the font for the username                                                                                 | 0xDEF7        | 0xDEF7        |
-| `FontPaletteName3`         |                                                                                                                                 | 0xC631        | 0xC631        |
-| `FontPaletteName4`         |                                                                                                                                 | 0xA108        | 0xA108        |
+| `FontPaletteUsername1`     | The override transparent color of the font for the username                                                                     | 0x0000        | 0x0000        |
+| `FontPaletteUsername2`     | The override color of the font for the username                                                                                 | 0xDEF7        | 0xDEF7        |
+| `FontPaletteUsername3`     |                                                                                                                                 | 0xC631        | 0xC631        |
+| `FontPaletteUsername4`     |                                                                                                                                 | 0xA108        | 0xA108        |
 | `StartTextUserPalette`     | Whether or not to use the DS Profile color for the palette of the start text                                                    |               | 1             |
 | `StartBorderUserPalette`   | Whether or not to use the DS Profile color for the palette of the start border                                                  |               | 1             |
 | `ButtonArrowUserPalette`   | Whether or not to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen                     |               | 1             |

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -7,13 +7,14 @@ title: How to Create DSi/3DS Skins
 description: How to make custom DSi and 3DS skins for TWiLight Menu++
 ---
 
-To make a TWiLight Menu++ skin you will need an image editor capable of exporting `.png` files, 16 <abbr title="Bits Per Pixel">BPP</abbr> `.bmp` files or `.png` files, and 4 BPP `.bmp` files. Ideally it should also be able to manually rearrange image palettes. [GIMP](https://www.gimp.org) is recommended and will be used for this guide as it's capable of everything needed.
+To make a TWiLight Menu++ skin, you will need an image editor capable of exporting `.png` files, 16 <abbr title="Bits Per Pixel">BPP</abbr> `.bmp` files or `.png` files, and 4 BPP `.bmp` files. Ideally, it should also be able to manually rearrange image palettes. [GIMP](https://www.gimp.org) is recommended and will be used for this guide, as it's capable of everything needed.
 
 ## Part 1: Download the examples
-The first thing you should do is download the [example skins](/assets/files/skin-examples.zip). These can be used as a base for your skin and are already in the correct format so if you have issues later on you can compare with these.
+The first thing you should do is download the [example skins](/assets/files/skin-examples.zip). These can be used as a base for your skin and are already in the correct format, so if you have issues later on, you can compare with these.
 
 ## Part 2: Editing images
-Download and install [GIMP](https://www.gimp.org), you can use a different editor if you want but this guide uses GIMP.
+Download and install [GIMP](https://www.gimp.org)
+- Other image editors such as Photoshop may work, but GIMP is what will be used in this guide
 
 Once installed, open GIMP and select `Windows` -> `Dockable Dialogs` -> `Colormap`. This opens the colormap dialog, which will be helpful when editing paletted images.
 
@@ -21,6 +22,7 @@ You can now open whichever image you want to edit in GIMP and continue to the se
 
 ### Background textures (`background` folder)
 These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
+- If using BMP files, you can set them to 16-bit under Advanced Options while exporting. You may need to do this each time you export as BMP
 
 | Texture             | Description                                                                                            |
 | ------------------- | ------------------------------------------------------------------------------------------------------ |
@@ -35,9 +37,9 @@ These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
 | top                 | The top screen background texture                                                                      |
 
 ### Battery textures (`battery` folder)
-These must be PNG files, any file will work however only 100% transparency will work. Any pixel that is transparent in one icon should be transparent in all of them so that it's properly overwritten on change.
+These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.
 
-| Texture            | Description                                                                 |
+| Texture            | Description/Notes                                                           |
 | ------------------ | --------------------------------------------------------------------------- |
 | battery0           | Flashes with `battery1` when the battery is very low                        |
 | battery1           | 0-4 are used in DSi mode                                                    |
@@ -57,15 +59,15 @@ These must be PNG files, any file will work however only 100% transparency will 
 ### Paletted textures (`grf` folder)
 These must be 4 BPP (16 color) BMP files files.
 
-To edit these in GIMP select `Image` -> `Mode` -> `RGB` to allow changing colors, then when done changing colors select `Image` -> `Mode` -> `Indexed...` to convert back to paletted. When switching to indexed, ensure that `Generate optimum palette` is checked and `Maximum number of colors` is set to `16`.
+To edit these in GIMP, select `Image` -> `Mode` -> `RGB` to allow changing colors, then when done changing colors, select `Image` -> `Mode` -> `Indexed...` to convert back to paletted. When switching to indexed, ensure that `Generate optimum palette` is checked and `Maximum number of colors` is set to `16`.
 
 **Note:** Some images in the DSi theme have their palettes overridden based on the user's profile color. If editing the colors of these ensure that the `UserPalette` option for it in the `theme.ini` is set to `0`.
 
 After converting to indexed, go to the colormap dialog and ensure the transparent color (#FF00FF) is color #0 in the colormap. If it isn't, right click in the colormap and select `Rearrange Colormap...` then move the transparent color to be the first color in the colormap and select `OK`.
 
-If there are fewer than 16 colors in your final colormap press the `+` button at the bottom of the colormap dialog until you have 16 colors.
+If there are fewer than 16 colors in your final colormap, press the `+` button at the bottom of the colormap dialog until you have 16 colors.
 
-When exporting it's recommended to check the `Do not write color space information` box under the `Compatibility Options` dropdown.
+When exporting, it's recommended to check the `Do not write color space information` box under the `Compatibility Options` dropdown.
 
 | Texture       | Description                                                                                     |
 | ------------- | ----------------------------------------------------------------------------------------------- |
@@ -120,7 +122,7 @@ These must be PNG files.
 | topbg      | Background for the top screen on any other DS model |
 
 ### UI textures (`ui` folder)
-These must be PNG files, any file will work however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all related textures so that it's properly overwritten on change.
+These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.
 
 | Texture          | Description                                             |
 | ---------------- | ------------------------------------------------------- |
@@ -133,9 +135,10 @@ These must be PNG files, any file will work however only 100% transparency will 
 Only used for the 3DS theme, `3dsRotatingCubes.rvid` is a Rocket Video file. For more information on converting videos to rvid, read [Converting a video to .rvid](https://github.com/RocketRobz/Vid2RVID/wiki/Converting-a-video-to-.rvid) on the Vid2RVID wiki. If you don't want this to be drawn you can simply delete it.
 
 ### Volume textures (`volume` folder)
-These must be PNG files, any file will work however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them so that it's properly overwritten on change.
+These must be PNG files. Transparency is supported, however only 100% transparency will work. Any pixel that is transparent in one texture should be transparent in all of them, so that it's properly overwritten on change.
 
-| Texture | Description                      |
+
+| Texture | Description/Notes                |
 | ------- | -------------------------------- |
 | volume0 | Volume is only shown in DSi mode |
 | volume1 | 0 is muted, 4 is full volume     |
@@ -144,9 +147,9 @@ These must be PNG files, any file will work however only 100% transparency will 
 | volume4 |                                  |
 
 ## Theme configuration (`theme.ini` file)
-You may configure various options on how the theme is drawn in the `theme.ini` to accommodate larger sprites or textures. For true/false options `0` is false and `1` is true. Options with a blank default value for a theme are unused for that theme.
+You may configure various options on how the theme is drawn in the `theme.ini` to accommodate larger graphics or different layouts. For true/false options, `0` is false, and `1` is true. Options with a blank default value for a theme are unused in that theme.
 
-| Value                      | Description                                                                                                                     | Default (3DS) | Default (DSi) |
+| Value                      | Description/Notes                                                                                                               | Default (3DS) | Default (DSi) |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------- |
 | `StartBorderRenderY`       | The initial Y position of the Start Border                                                                                      | 92            | 81            |
 | `StartBorderSpriteW`       | The width of the start border sprite. Note that the start border texture is exactly half of the full border                     | 32            | 32            |
@@ -215,11 +218,14 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 ### Macro Mode options
 You may add specific override options to `theme.ini` for use in Macro Mode. To do this, add `[MACRO]` to a blank line at the bottom of the configuration file, then add any specified configurations below it.
 
+## Custom background music and sound effects
+The DSi and 3DS themes also support custom music. See [DSi/3DS skins - Custom SFX](custom-dsi-3ds-sfx) for more details.
+
+## Custom fonts
+You may put [Custom Fonts](custom-fonts) in the `font` folder for use in the skin. You can also add override fonts for the date & time using `date_time.nftr`, and the console username with `username.nftr`.
+
 ## Part 3: Adding to TWiLight Menu++
 Once you've edited some graphics and would like to test your skin, simply copy your skin folder (the folder containing the `background`, `battery`, etc folders) to `sd:/_nds/TWiLightMenu/3dsmenu/themes/` or `sd:/_nds/TWiLightMenu/dsimenu/themes/` for 3DS and DSi theme skins respectively.
 
 ## Part 4: Sharing your skin
 Once you've completed your skin, you can share it with the community by creating a Pull Request adding it to the [DS-Homebrew/twlmenu-extras](https://github.com/DS-Homebrew/twlmenu-extras) GitHub repository in a `.7z` file. If you're unfamiliar with using git you can also simply create an issue on that repository with a zip file of your skin requesting it be added.
-
-## Custom background music and sound effects
-The DSi and 3DS themes also support custom music. See [DSi/3DS skins - Custom SFX](custom-dsi-3ds-sfx) for more details.

--- a/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
+++ b/pages/_en-US/twilightmenu/custom-dsi-3ds-skins.md
@@ -22,13 +22,15 @@ You can now open whichever image you want to edit in GIMP and continue to the se
 ### Background textures (`background` folder)
 These can be PNG files or 16-bit (`A1 R5 G5 B5` or `X1 R5 G5 B5`) BMP files.
 
-| Texture          | Description                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------------- |
-| bottom           | The bottom background texture when not hovering over an icon                                      |
-| bottom_bubble    | The bottom background texture when hovering over an icon                                          |
-| bottom_ds        | For the 3DS theme, the bottom background texture when not hovering over an icon when on a DS lite |
-| bottom_bubble_ds | For the 3DS theme, the bottom background texture when hovering over an icon when on a DS lite     |
-| top              |                                                                                                   |
+| Texture            | Description                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------ |
+| bottom             | The bottom background texture when not hovering over an icon                                           |
+| bottom_bubble      | The bottom background texture when hovering over an icon                                               |
+| bottom_ds          | For the 3DS theme, the bottom background texture when not hovering over an icon when on a DS Phat/Lite |
+| bottom_bubble_ds   | For the 3DS theme, the bottom background texture when hovering over an icon when on a DS Phat/Lite     |
+| bottom_bubble_macro| For the DSi theme, the background texture when hovering over an icon using Macro Mode                  |
+| bottom_moving      | For the DSi theme, the bottom background texture when moving an icon
+| top                | The top screen background texture                                                                      |
 
 ### Battery textures (`battery` folder)
 These must be PNG files, any file will work however only 100% transparency will work. Any pixel that is transparent in one icon should be transparent in all of them so that it's properly overwritten on change.
@@ -77,10 +79,12 @@ When exporting it's recommended to check the `Do not write color space informati
 | dialogbox     | The background of the dialog box that slides down                                               |
 | folder        | The icon for folders                                                                            |
 | icon_a26      | The icon for Atari 2600 games                                                                   |
+| icon_col      | The icon for Colecovision games                                                                 |
 | icon_gb       | The icon for Game Boy games                                                                     |
-| icon_gba      | The icon for GBA games (all themes) and the top icon to launch GBARunner2 (3DS Theme)           |
+| icon_gba      | The icon for GBA games                                                                          |
 | icon_gbamode  | The icon for native GBA Mode                                                                    |
 | icon_gg       | The icon for Game Gear games                                                                    |
+| icon_img      | The icon for BMP, GIF, and PNG images                                                           |
 | icon_int      | The icon for Intellivision games                                                                |
 | icon_m5       | The icon for Sord M5 games                                                                      |
 | icon_manual   | The icon for the manual                                                                         |
@@ -118,7 +122,6 @@ These must be PNG files, any file will work however only 100% transparency will 
 
 | Texture          | Description                                             |
 | ---------------- | ------------------------------------------------------- |
-| date_time_font   | The font to display the date and time                   |
 | Lshoulder        | The left shoulder                                       |
 | Lshoulder_greyed | The left shoulder when there are no pages to the left   |
 | Rshoulder        | The right shoulder                                      |
@@ -153,31 +156,35 @@ You may configure various options on how the theme is drawn in the `theme.ini` t
 | `BubbleTipSpriteH`       | The height of the bubble tip sprite                                                                          | 7             | 8             |
 | `TitleboxRenderY`        | The initial Y position of the title text box                                                                 | 96            | 85            |
 | `TitleboxTextY`          | The initial Y position of the title text                                                                     | 55            | 30            |
-| `TitleboxTextW`          | The maximum width of the title text                                                                          | 200           | 240           |
+| `TitleboxTextW`          | The maximum width of the title text                                                                          | 200           | 240            |
 | `MacroTitleboxTextY`     | The initial Y position of the title text in macro mode                                                       |               | 40            |
-| `MacroTitleboxTextW`     | The maximum width of the title text in macro mode                                                            |               | 224           |
-| `TitleboxTextLarge`      | Whether to use the large font for the title text                                                             | 0             | 1             |
-| `TitleboxMaxLines`       | The maximum lines of text to show of the title                                                               | 3             | 4             |
-| `VolumeRenderX`          | The X position on the top screen to draw the volume icon                                                     | 4             | 4             |
-| `VolumeRenderY`          | The Y position on the top screen to draw the volume icon                                                     | 5             | 5             |
-| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172           |
-| `ShoulderLRenderX`       | The X position on the top screen to draw the left shoulder                                                   | 0             | 0             |
-| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172           |
-| `ShoulderRRenderX`       | The X position on the top screen to draw the right shoulder                                                  | 178           | 178           |
-| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5             |
-| `BatteryRenderX`         | The X position on the top screen to draw the battery icon                                                    | 235           | 235           |
+| `MacroTitleboxTextW`     | The maximum width of the title text in macro mode                                                            |               | 224            |
+| `TitleboxTextLarge`      | Whether to use the large font for the title text                                                             | 0             | 1              |
+| `TitleboxMaxLines`       | The maximum lines of text to show of the title                                                               | 3             | 4              |
+| `VolumeRenderX`          | The X position on the top screen to draw the volume icon                                                     | 4             | 4              |
+| `VolumeRenderY`          | The Y position on the top screen to draw the volume icon                                                     | 5             | 5              |
+| `ShoulderLRenderY`       | The Y position on the top screen to draw the left shoulder                                                   | 172           | 172            |
+| `ShoulderLRenderX`       | The X position on the top screen to draw the left shoulder                                                   | 0             | 0              |
+| `ShoulderRRenderY`       | The Y position on the top screen to draw the right shoulder                                                  | 172           | 172            |
+| `ShoulderRRenderX`       | The X position on the top screen to draw the right shoulder                                                  | 178           | 178            |
+| `BatteryRenderY`         | The Y position on the top screen to draw the battery icon                                                    | 5             | 5              |
+| `BatteryRenderX`         | The X position on the top screen to draw the battery icon                                                    | 235           | 235            |
 | `FontPalette1`           | The transparent color of the font, unused for default fonts                                                  | 0x0000        | 0x0000        |
 | `FontPalette2`           | The colors of the font, use [this site](http://www.conradshome.com/html2bgr15/) to convert                   | 0xDEF7        | 0xDEF7        |
 | `FontPalette3`           |                                                                                                              | 0xC631        | 0xC631        |
 | `FontPalette4`           |                                                                                                              | 0xA108        | 0xA108        |
-| `StartTextUserPalette`   | Whether to use the DS Profile color for the palette of the start text                                        |               | 1             |
-| `StartBorderUserPalette` | Whether to use the DS Profile color for the palette of the start border                                      |               | 1             |
-| `ButtonArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen         |               | 1             |
-| `MovingArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow shown when moving icons                     |               | 1             |
-| `LaunchDotsUserPalette`  | Whether to use the DS Profile color for the palette of the launch dots                                       |               | 1             |
-| `DialogBoxUserPalette`   | Whether to use the DS Profile color for the palette of the dialog box                                        |               | 1             |
-| `RenderPhoto`            | Whether or not to draw a photo on the top screen                                                             | 0             | 1             |
-| `RotatingCubesRenderY`   | The Y position on the top screen to draw the rotating cubes                                                  | 78            |               |
+| `FontPaletteDateTime1`   | The transparent color of the font for the date and time                                                      | 0x0000        | 0x0000        |
+| `FontPaletteDateTime2`   | The color of the font for the date and time                                                                  | 0xDEF7        | 0xA529        |
+| `FontPaletteDateTime3`   |                                                                                                              | 0xC631        | 0xBDEF        |
+| `FontPaletteDateTime4`   |                                                                                                              | 0xA108        | 0xD6B5        |
+| `StartTextUserPalette`   | Whether to use the DS Profile color for the palette of the start text                                        |               | 1              |
+| `StartBorderUserPalette` | Whether to use the DS Profile color for the palette of the start border                                      |               | 1              |
+| `ButtonArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow buttons on the bottom of the screen         |               | 1              |
+| `MovingArrowUserPalette` | Whether to use the DS Profile color for the palette of the arrow shown when moving icons                     |               | 1              |
+| `LaunchDotsUserPalette`  | Whether to use the DS Profile color for the palette of the launch dots                                       |               | 1              |
+| `DialogBoxUserPalette`   | Whether to use the DS Profile color for the palette of the dialog box                                        |               | 1              |
+| `RenderPhoto`            | Whether or not to draw a photo on the top screen                                                             | 0             | 1              |
+| `RotatingCubesRenderY`   | The Y position on the top screen to draw the rotating cubes                                                  | 78            |                |
 
 ## Part 3: Adding to TWiLight Menu++
 Once you've edited some graphics and would like to test your skin, simply copy your skin folder (the folder containing the `background`, `battery`, etc folders) to `sd:/_nds/TWiLightMenu/3dsmenu/themes/` or `sd:/_nds/TWiLightMenu/dsimenu/themes/` for 3DS and DSi theme skins respectively.

--- a/pages/_en-US/twilightmenu/custom-fonts.md
+++ b/pages/_en-US/twilightmenu/custom-fonts.md
@@ -10,8 +10,8 @@ description: How to use custom fonts with TWiLight Menu++
 TWiLight Menu++ can use custom fonts in NFTR (Nitro FonT Resource) format. They will be used in Settings, the Manual's titles, and in the Nintendo DSi, Nintendo 3DS, SEGA Saturn, and Homebrew Launcher themes.
 
 ### Included font info
-There are three fonts included with TWiLight Menu++. When TWiLight Menu++ is running in DSi Mode they all contain all of the characters that should be needed for all of the languages TWiLight is translated to, but when running in DS Mode they are more limited due to RAM limitations. They are as follows:
-- Default: This uses the official DSi font as it's primary font and supports all characters that are used in TWiLight Menu++ itself in all languages in DS mode
+There are three fonts included with TWiLight Menu++. When TWiLight Menu++ is running in DSi Mode, they all contain all of the characters that should be needed for all of the languages TWiLight is translated to, but when running in DS Mode they are more limited due to RAM limitations. They are as follows:
+- Default: This uses the official DSi font as its primary font, and supports all characters that are used in TWiLight Menu++ itself in all languages in DS mode
 - Chinese (Simplified): This uses Noto Sans CS as the primary font and has significantly more Chinese (Simplified) characters in DS Mode, at the cost of characters for other languages
 - Korean: This is identical to Default in DSi Mode, but in DS Mode has a more complete set of hangul, at the cost of characters for other languages
 
@@ -21,6 +21,11 @@ Custom fonts are loaded from `sd:/_nds/TWiLightMenu/extras/fonts/[font name]/[fo
 - `small-ds.nftr`, `small-dsi.nftr`, or `small.nftr`: The smaller font used for most other text
 
 The `-ds` and `-dsi` files have higher priority than the normal one and if found will be used when TWiLight Menu++ is running in DS or DSi Mode respectively.
+
+### Skin fonts
+You may add fonts to [custom DSi/3DS theme skins](custom-dsi-3ds-skins), which will override whatever is set in TWiLight Menu++ settings. These fonts go in the `font` folder, in the skin's root folder.
+
+Custom skins can additionally use override fonts for the date & time using `date_time.nftr`, and the console username with `username.nftr`.
 
 ### Generating custom fonts
 You can make your own fonts using a utility such as Pk11's [nftr-editor](https://pk11.us/nftr-editor/). To regenerate one of TWiLight Menu++'s existing fonts using it:


### PR DESCRIPTION
The current commit adds:
- Some edits
- Add a couple of missing backgrounds and icons
- Remove date_time_font image and add FontPaletteDateTime1-4 (for next release)
  - Not 100% certain on the validity of the default colors for the palette

This PR isn't yet complete. I'd like to add some things before merging, but I need to sleep soon and this has a fair amount of information that needs to be added, so I'm leaving it as a draft PR so I (or anyone else) can come back to it later to complete it.
Currently, the following needs to be added:
- [x] `Date`/`Time`/`UsernameRenderX/Y` and their defaults ([45cd452](https://github.com/DS-Homebrew/TWiLightMenu/commit/45cd45297f1446eb7a250eacae2360e9648be30f))
- [x] Information on `[MACRO]` settings ([45cd452](https://github.com/DS-Homebrew/TWiLightMenu/commit/45cd45297f1446eb7a250eacae2360e9648be30f))
- [x] `FontPaletteTitlebox`/`Dialog`/`Overlay` and their defaults ([3583476](https://github.com/DS-Homebrew/TWiLightMenu/commit/35834762c8e9cd6530aee5dd056c03dfb325f60c))
- [x] Information on custom/skin fonts themselves, maybe with some stuff on the Custom Fonts page, I'm not sure
- [x] Add `PurpleBatteryAvailable` ([473f19b](https://github.com/DS-Homebrew/TWiLightMenu/commit/473f19bc42ff043af15b9dc4706de4349bd2cdc1))
- [x] Add new Macro Mode backgrounds ([8985b7e](https://github.com/DS-Homebrew/TWiLightMenu/commit/8985b7e37b8ed479fa35e68044c8afa7a0333bd3))
- [x] Add `FontPaletteName` ([ed4de26](https://github.com/DS-Homebrew/TWiLightMenu/commit/ed4de261d947b74f3289475754c784d228e95e77))
- [x] Add `playStartupJingle` and `startupJingleDelayAdjust` (a while ago)