### PR TITLE
rules: switch to includes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ defaults:
       layout: wiki
 
 exclude: [
+  "**/community/rules/*",
   "fix in-context.sh",
   CONTRIBUTING.md,
   CNAME,

--- a/pages/_en-US/community/discord-rules.md
+++ b/pages/_en-US/community/discord-rules.md
@@ -9,106 +9,33 @@ description: The rules for the DS⁽ⁱ⁾ Mode Hacking Discord server
 
 This page provides more details to the rules outlined in the [#info-and-rules](https://discord.com/channels/283769550611152897/626620520330428436) channel in the Discord server. If you have any further questions, ask in [#community-meta](https://discord.com/channels/283769550611152897/715651368391671919). Note that the [English version of the rules](/community/discord-rules) is the canonical version and any potential discrepancies in translations will not affect their enforcement.
 
-### 1. Do not act disrespectfully towards others and their beliefs
+{% include_relative rules/1.md %}
 
-- This applies to everyone regardless of their role or level of activity in this server, even if they aren’t on the server
-- Do not backseat moderate or try to "help" when a moderator is already dealing with a situation
-- Reminders of the rules are fine, as long as you remain respectful
-- Credit the creator(s) when sending something if you know who created it (exception being when the included work already credits said author)
+{% include_relative rules/2.md %}
 
-### 2. Follow standards set in project-development servers
+{% include_relative rules/3.md %}
 
-- Asking to ask is not only ironic, but defeats the point of having a help channel such as #nds-help, where all help questions are intended to be directed towards
-- Arbitrary release dates aren't part of our schedule to publish high quality tested applications, and expecting them to be pre-determined/ready on demand interferes with our release schedule. Those not wanting to be constrained by these limitations should instead use nightly builds if the project offers it
-- Handholding is not helping; users are expected to do research on the subject matter, whether it's by reading the pinned messages/#useful-resources or using a search engine to find links
-   - Overlooking this rule for legitimate reasons is allowed, at moderators decision on what is considered legitimate
+{% include_relative rules/4.md %}
 
-### 3. Keep a positive-environment in the server
+{% include_relative rules/5.md %}
 
-- Curse words aren't prohibited (you're on the internet; expect it), but edgelords and slurs aren't welcome
-- Conversational rants are allowed as long as it's not purely for the sake of venting
-   - Prevent discussions being repeats of frustrations already found so commonly elsewhere (ie: Twitter) by introducing another factor not well known or discussed
-   - Starting off a topic with something bad to say about it? Make sure to not instantly start the whole convo to be negative
+{% include_relative rules/6.md %}
 
-### 4. Maintain the chat quality to the expectations set by the environment
+{% include_relative rules/7.md %}
 
-- Monologuing to the point of discouraging others from interacting or having the message overflow an average mobile screen should have the messages moved to a dedicated page, such as a server thread or Mystbin: https://mystb.in/
-- GIFs to complement messages are fun, but GIFs made to replace conversation is just irritating and bandwidth wasting.
-- Keep needed messages for your point to a minimal, by:
-   - NOT duplicating messages, especially in different channels
-   - NOT posting for the sake of posting ("chat is dead", copypastas, etc)
-   - NOT sending multiple messages with few words each to build a sentence (ie: popcorning)
-   - using reactions to post simple emoji's responding to another's message (for the message immediately above, type `+:emojiname:` as a shortcut)
+{% include_relative rules/8.md %}
 
-**Moderators may request a discussion to stop, and users are expected to comply with its request, even if it doesn't fall into any of the above examples**
+{% include_relative rules/9.md %}
 
-### 5. Do not self-promote with no context or without explicit staff permission
+{% include_relative rules/10.md %}
 
-- Giving links to other Discord servers on request is allowed, but please ask a moderator in a DM before advertising a server without prior context
-- DM advertisements aren't allowed, both by the Discord Terms of Service and our server rules, mass DM advertisement (with proof) will land you a ban
-- Joining for the purpose of advertising your discord server will land you a ban and your advertisements will be deleted
-- Any compromised account will get banned, with the sent messages from the bot being removed. If the account is later retrieved, please contact one of the staff members
+{% include_relative rules/11.md %}
 
-### 6. Avoid piracy discussion
+{% include_relative rules/12.md %}
 
-Examples for what breaks this rule includes:
-- Mentioning/Linking piracy websites/tools
-- Encouraging piracy, whether by assisting others with it or justifying it
-- Uploading pirated or NDA-breaking content (ROMs compiled via official licensed SDKs, tools, etc...)
+{% include_relative rules/13.md %}
 
-Example for what DOESN'T break this rule being:
-- Discussing any of the publicly-known leaked content, as long as no builds, source code or even unrelated files are shared
-
-Discord’s Terms of Service follow the US law and as such, is subject to the US definition of piracy regardless of wherever the user lives in the US or not
-- For more information on what is piracy or not, we suggest reading [eip’s piracy definition page](https://3ds.eiphax.tech/piracy.html) (Disclaimer: We are not lawyers)
-
-### 7. Keep conversations within their respective channels
-
-- Even if they are related, sometimes another channel would be more suitable
-   - Check the channel topics for where to ask questions or have discussion
-- Sometimes, even an entirely different server is preferable, we don't have the answers to everything
-   - There are some related servers in [#useful-resources](https://discord.com/channels/283769550611152897/638041441079263283) and the pins of other channels
-
-### 8. Keep all conversations in English
-
-- We are not able to easily moderate content in other languages
-- We suggest using [DeepL](https://www.deepl.com/translator) for translation
-- Exceptions may be granted in case translation fails and there are trusted people that know your language and are able to help
-
-### 9. You may not have an alternative account on this server without staff permission
-
-- One account per person at a time (except when approved by a staff member), be sure to leave this server on your other account before joining with a new one
-- Punishments apply to the person, not the account, any subsequent accounts made for the purposes of punishment evasion will result in both accounts being banned
-
-### 10. Keep names/nicknames exclusively alphanumeric and do not hoist
-
-- Users with a nickname/username that is not easily readable for an English speaker or mentionable with an English (US) keyboard will be assigned a new nickname
-- Avoid purposely putting characters in the beginning of the name to change your spot in the member list, those characters will be removed
-
-### 11. Do not send unsolicited DMs to other users
-
-- Please ask before sending a Direct Message to others and respect those not wanting to communicate
-   - Even if your actions aren't malicious, they could be disturbing or otherwise unwanted
-- Things that happen in Direct Messages **are** the business of the server since unless you both share another server or are friends, you wouldn't be able to reach each other
-- Examples of what not to do include DM advertising, purposely redirecting users to DMs from normal chat (such as support) to break rules, and harassment
-
-### 12. Do not bring external drama, NSFW, or illegal content into the server
-
-- If you are banned in other servers, avoid talking about it here
-   - We can not help you get unbanned from other servers, that is the decision of the staff members there
-- Do not post anything that is not considered safe for work (e.g. sexual content, extreme violence, drugs)
-- Accounts with disturbing avatars will be kicked, then leading to a ban if they keep said avatar on return
-- Despite adult content being banned, users are still required to be thirteen and over in order to participate on this Discord server as per the Discord TOS
-
-### 13. Do not talk about or do actions pertaining to breaking other Discord TOS
-
-- Breaking anything covered by either Discord's [Terms of Service](https://discord.com/terms) or [community guidelines](https://discord.com/guidelines), regardless of whether mentioned by the above or not, will land one a ban
-
-### 14. Do not try to evade the rules as this will be treated as breaking them
-
-- If you don't understand any of the rules, feel free to ask for further clarification
-- Breaking the rules and then claiming that you “didn’t know” will still make you guilty of breaking them
-- Trying to get around the rules by speaking in vague terms also counts as breaking them
+{% include_relative rules/14.md %}
 
 ## Consequences
 

--- a/pages/_en-US/community/rules/1.md
+++ b/pages/_en-US/community/rules/1.md
@@ -1,0 +1,6 @@
+### 1. Do not act disrespectfully towards others and their beliefs
+
+- This applies to everyone regardless of their role or level of activity in this server, even if they aren’t on the server
+- Do not backseat moderate or try to "help" when a moderator is already dealing with a situation
+- Reminders of the rules are fine, as long as you remain respectful
+- Credit the creator(s) when sending something if you know who created it (exception being when the included work already credits said author)

--- a/pages/_en-US/community/rules/10.md
+++ b/pages/_en-US/community/rules/10.md
@@ -1,0 +1,4 @@
+### 10. Keep names/nicknames exclusively alphanumeric and do not hoist
+
+- Users with a nickname/username that is not easily readable for an English speaker or mentionable with an English (US) keyboard will be assigned a new nickname
+- Avoid purposely putting characters in the beginning of the name to change your spot in the member list, those characters will be removed

--- a/pages/_en-US/community/rules/11.md
+++ b/pages/_en-US/community/rules/11.md
@@ -1,0 +1,6 @@
+### 11. Do not send unsolicited DMs to other users
+
+- Please ask before sending a Direct Message to others and respect those not wanting to communicate
+   - Even if your actions aren't malicious, they could be disturbing or otherwise unwanted
+- Things that happen in Direct Messages **are** the business of the server since unless you both share another server or are friends, you wouldn't be able to reach each other
+- Examples of what not to do include DM advertising, purposely redirecting users to DMs from normal chat (such as support) to break rules, and harassment

--- a/pages/_en-US/community/rules/12.md
+++ b/pages/_en-US/community/rules/12.md
@@ -1,0 +1,7 @@
+### 12. Do not bring external drama, NSFW, or illegal content into the server
+
+- If you are banned in other servers, avoid talking about it here
+   - We can not help you get unbanned from other servers, that is the decision of the staff members there
+- Do not post anything that is not considered safe for work (e.g. sexual content, extreme violence, drugs)
+- Accounts with disturbing avatars will be kicked, then leading to a ban if they keep said avatar on return
+- Despite adult content being banned, users are still required to be thirteen and over in order to participate on this Discord server as per the Discord TOS

--- a/pages/_en-US/community/rules/13.md
+++ b/pages/_en-US/community/rules/13.md
@@ -1,0 +1,3 @@
+### 13. Do not talk about or do actions pertaining to breaking other Discord TOS
+
+- Breaking anything covered by either Discord's [Terms of Service](https://discord.com/terms) or [community guidelines](https://discord.com/guidelines), regardless of whether mentioned by the above or not, will land one a ban

--- a/pages/_en-US/community/rules/14.md
+++ b/pages/_en-US/community/rules/14.md
@@ -1,0 +1,5 @@
+### 14. Do not try to evade the rules as this will be treated as breaking them
+
+- If you don't understand any of the rules, feel free to ask for further clarification
+- Breaking the rules and then claiming that you “didn’t know” will still make you guilty of breaking them
+- Trying to get around the rules by speaking in vague terms also counts as breaking them

--- a/pages/_en-US/community/rules/2.md
+++ b/pages/_en-US/community/rules/2.md
@@ -1,0 +1,6 @@
+### 2. Follow standards set in project-development servers
+
+- Asking to ask is not only ironic, but defeats the point of having a help channel such as #nds-help, where all help questions are intended to be directed towards
+- Arbitrary release dates aren't part of our schedule to publish high quality tested applications, and expecting them to be pre-determined/ready on demand interferes with our release schedule. Those not wanting to be constrained by these limitations should instead use nightly builds if the project offers it
+- Handholding is not helping; users are expected to do research on the subject matter, whether it's by reading the pinned messages/#useful-resources or using a search engine to find links
+   - Overlooking this rule for legitimate reasons is allowed, at moderators decision on what is considered legitimate

--- a/pages/_en-US/community/rules/3.md
+++ b/pages/_en-US/community/rules/3.md
@@ -1,0 +1,6 @@
+### 3. Keep a positive-environment in the server
+
+- Curse words aren't prohibited (you're on the internet; expect it), but edgelords and slurs aren't welcome
+- Conversational rants are allowed as long as it's not purely for the sake of venting
+   - Prevent discussions being repeats of frustrations already found so commonly elsewhere (ie: Twitter) by introducing another factor not well known or discussed
+   - Starting off a topic with something bad to say about it? Make sure to not instantly start the whole convo to be negative

--- a/pages/_en-US/community/rules/4.md
+++ b/pages/_en-US/community/rules/4.md
@@ -1,0 +1,11 @@
+### 4. Maintain the chat quality to the expectations set by the environment
+
+- Monologuing to the point of discouraging others from interacting or having the message overflow an average mobile screen should have the messages moved to a dedicated page, such as a server thread or Mystbin: https://mystb.in/
+- GIFs to complement messages are fun, but GIFs made to replace conversation is just irritating and bandwidth wasting.
+- Keep needed messages for your point to a minimal, by:
+   - NOT duplicating messages, especially in different channels
+   - NOT posting for the sake of posting ("chat is dead", copypastas, etc)
+   - NOT sending multiple messages with few words each to build a sentence (ie: popcorning)
+   - using reactions to post simple emoji's responding to another's message (for the message immediately above, type `+:emojiname:` as a shortcut)
+
+**Moderators may request a discussion to stop, and users are expected to comply with its request, even if it doesn't fall into any of the above examples**

--- a/pages/_en-US/community/rules/5.md
+++ b/pages/_en-US/community/rules/5.md
@@ -1,0 +1,6 @@
+### 5. Do not self-promote with no context or without explicit staff permission
+
+- Giving links to other Discord servers on request is allowed, but please ask a moderator in a DM before advertising a server without prior context
+- DM advertisements aren't allowed, both by the Discord Terms of Service and our server rules, mass DM advertisement (with proof) will land you a ban
+- Joining for the purpose of advertising your discord server will land you a ban and your advertisements will be deleted
+- Any compromised account will get banned, with the sent messages from the bot being removed. If the account is later retrieved, please contact one of the staff members

--- a/pages/_en-US/community/rules/6.md
+++ b/pages/_en-US/community/rules/6.md
@@ -1,0 +1,12 @@
+### 6. Avoid piracy discussion
+
+Examples for what breaks this rule includes:
+- Mentioning/Linking piracy websites/tools
+- Encouraging piracy, whether by assisting others with it or justifying it
+- Uploading pirated or NDA-breaking content (ROMs compiled via official licensed SDKs, tools, etc...)
+
+Example for what DOESN'T break this rule being:
+- Discussing any of the publicly-known leaked content, as long as no builds, source code or even unrelated files are shared
+
+Discord’s Terms of Service follow the US law and as such, is subject to the US definition of piracy regardless of wherever the user lives in the US or not
+- For more information on what is piracy or not, we suggest reading [eip’s piracy definition page](https://3ds.eiphax.tech/piracy.html) (Disclaimer: We are not lawyers)

--- a/pages/_en-US/community/rules/7.md
+++ b/pages/_en-US/community/rules/7.md
@@ -1,0 +1,6 @@
+### 7. Keep conversations within their respective channels
+
+- Even if they are related, sometimes another channel would be more suitable
+   - Check the channel topics for where to ask questions or have discussion
+- Sometimes, even an entirely different server is preferable, we don't have the answers to everything
+   - There are some related servers in [#useful-resources](https://discord.com/channels/283769550611152897/638041441079263283) and the pins of other channels

--- a/pages/_en-US/community/rules/8.md
+++ b/pages/_en-US/community/rules/8.md
@@ -1,0 +1,5 @@
+### 8. Keep all conversations in English
+
+- We are not able to easily moderate content in other languages
+- We suggest using [DeepL](https://www.deepl.com/translator) for translation
+- Exceptions may be granted in case translation fails and there are trusted people that know your language and are able to help

--- a/pages/_en-US/community/rules/9.md
+++ b/pages/_en-US/community/rules/9.md
@@ -1,0 +1,4 @@
+### 9. You may not have an alternative account on this server without staff permission
+
+- One account per person at a time (except when approved by a staff member), be sure to leave this server on your other account before joining with a new one
+- Punishments apply to the person, not the account, any subsequent accounts made for the purposes of punishment evasion will result in both accounts being banned


### PR DESCRIPTION
This makes use of Jekyll's `include_relative` feature, which lets you split out certain subjects to different files.

This isn't strictly necessary, but I wrote it just because I didn't feel like maintaining the spaghetti code in TWLHelper lol