### PR TITLE
Migrate fully to GitHub Actions for Pages deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,13 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  doc-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -23,14 +26,23 @@ jobs:
         # Build the site using Jekyll
         run: JEKYLL_ENV=production bundle exec jekyll build
 
-        # Copy (or touch) other needed files
-        # .nojekyll: to tell GH Pages to not rebuild (lol)
-      - name: Post-Jekyll build copy files
-        run: touch _site/.nojekyll
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: _site # The folder the action should deploy.
-          clean: true # Automatically remove deleted files from the deploy branch
+  # Deployment job
+  deploy:
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Legacy deploy environments (including simply having something in gh-pages!) is deprecated too.

GitHub really wants us to use their deploy-pages system for this, so switch to it.