### PR TITLE
workflow: add automation of uploading source text to Crowdin

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,36 @@
+name: Upload source files to Crowdin
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'pages/en_US/**.md'
+      - '_data/en-US/**.json'
+      - 'assets/js/i18n/en-US.js'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+        # Build the site using Jekyll
+        # No point pushing to Crowdin if the site build is failing
+      - name: Test site build via Jekyll
+        run: JEKYLL_ENV=production bundle exec jekyll build
+
+      - name: Push to Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_TOKEN }}


### PR DESCRIPTION
This will push to Crowdin if a push to main branch was successful. This allows automation of syncing source text, making it less of a hassle to synchronize all translations.