### PR TITLE
Add clarification to leaked content discussion

### DIFF
--- a/pages/_en-US/community/rules/6.md
+++ b/pages/_en-US/community/rules/6.md
@@ -6,7 +6,7 @@ Examples for what breaks this rule includes:
 - Uploading pirated or NDA-breaking content (ROMs compiled via official licensed SDKs, tools, etc...)
 
 Example for what DOESN'T break this rule being:
-- Discussing any of the publicly-known leaked content, as long as no builds, source code or even unrelated files are shared
+- Discussing any of the publicly-known leaked content, as long as no builds, source code or even unrelated files are shared, and as long as the discussion is related to homebrew development.
 
 Discord’s Terms of Service follow the US law and as such, is subject to the US definition of piracy regardless of wherever the user lives in the US or not
 - For more information on what is piracy or not, we suggest reading [eip’s piracy definition page](https://3ds.eiphax.tech/piracy.html) (Disclaimer: We are not lawyers)


### PR DESCRIPTION
Since general discussion on leaked content is discouraged, this edit will limit discussion only to homebrew development (ie. adding support for a leaked prototype in nds-bootstrap, or how a leaked file may assist in building a repair tool).