### PR TITLE
ntrboot guide changes

### DIFF
--- a/pages/_en-US/ds-index/best-console.md
+++ b/pages/_en-US/ds-index/best-console.md
@@ -9,17 +9,17 @@ description: Looking at the features of each console to decide the best DS(i) mo
 
 The Nintendo DS, Nintendo DSi, Nintendo 3DS, and Nintendo 2DS consoles are all capable of running in DS(i) mode, as well as GBA games. To help decide which console is best for you, please read this page.
 
-| Features          | Nintendo DS                         | Nintendo DSi           | Nintendo 3DS/2DS            |
-| ----------------- | ----------------------------------- | ---------------------- | --------------------------- |
-| Max RAM           | 4MB (up to 36MB with RAM expansion) | 16MB                   | 32MB                        |
-| Max CPU Speed     | 67mhz                               | 133mhz[^1]             | 133mhz[^1]                  |
-| Camera            | No                                  | Yes                    | Yes                         |
-| Screen type       | TN(?)                               | TN (Regular), IPS (XL) | TN or IPS (varies by model) |
-| Touch sensitivity | Yes                                 | DSi mode only          | No                          |
-| Screen scaling    | No                                  | No                     | Yes[^2]                     |
-| Brightness levels | 2 (On/Off for Phat), 4 (Lite)[^3]   | 5                      | 5                           |
-| GBA Compatiblity  | Native, Near-Perfect[^4]            | Great                  | Native, Near-Perfect[^5]    |
-| DSiWare Support   | Yes, Partial[^6]                    | Yes[^7]                | Yes[^7]                     |
+| Features          | Nintendo DS                            | Nintendo DSi           | Nintendo 3DS/2DS            |
+| ----------------- | ---------------------------------------| ---------------------- | --------------------------- |
+| Max RAM           | 4MB (up to 36MB with RAM expansion)    | 16MB                   | 32MB                        |
+| Max CPU Speed     | 67mhz                                  | 133mhz[^1]             | 133mhz[^1]                  |
+| Camera            | No                                     | Yes                    | Yes                         |
+| Screen type       | TN(?), Frontlit (Phat), Backlit (Lite) | TN (Regular), IPS (XL) | TN or IPS (varies by model) |
+| Touch sensitivity | Yes                                    | DSi mode only          | No                          |
+| Screen scaling    | No                                     | No                     | Yes[^2]                     |
+| Brightness levels | 2 (On/Off for Phat), 4 (Lite)[^3]      | 5                      | 5                           |
+| GBA Compatiblity  | Native, Near-Perfect[^4]               | Great                  | Native, Near-Perfect[^5]    |
+| DSiWare Support   | Yes, Partial[^6]                       | Yes[^7]                | Yes[^7]                     |
 
 [^1]: DS games will run at 67mhz, but most can be configured to run at 133mhz, though certain games will have issues.
 [^2]: When launching in DS(i) mode, the screens are not properly scaled, and will not appear pixel-perfect. Holding START or SELECT button will disable screen scaling, but will reveal black borders around the screen images.

--- a/pages/_en-US/ds-index/ntrboot.md
+++ b/pages/_en-US/ds-index/ntrboot.md
@@ -6,7 +6,8 @@ category: guides
 title: ntrboot
 description: How to use ntrboot on a Nintendo DSi
 tabs:
-  - dsi: DS/DSi
+  - unhacked: Unhacked DS/DSi/3DS
+    dsi: DSi
     3ds: 3DS
 ---
 
@@ -15,9 +16,25 @@ tabs:
 ### Required hardware
 
 To use ntrboot on your DSi you will need:
-    - An ntrboot compatible flashcard. [Here's a list of working carts](https://www.flashcarts.net/ntrboot-ds-carts.html?tab=flashable). Ignore the pre-flashed ones as those use the 3DS version of ntrboot.
-    - A magnet to trigger ntrboot
-    - A second DSi/3DS in order to flash ntrboot to the flashcard
+  - An ntrboot compatible flashcard. [Here's a list of working carts](https://www.flashcarts.net/ntrboot-ds-carts.html?tab=flashable). Ignore the pre-flashed ones as those use the 3DS version of ntrboot.
+  - A magnet to trigger ntrboot
+  - A working DS/DSi/3DS in order to flash ntrboot to the flashcard
+
+{% capture tab-unhacked %}
+
+This method requires a working DS, DSi or 3DS console and does not require custom firmware
+{:.alert .alert-warning}
+
+1. Ensure your flashcart is set up with a working kernel that can load homebrew
+1. Create a folder named `ntrboot` on your flashcart's MicroSD card
+1. Download the [ntrboot image](/assets/files/default.gcd) and copy it to the `ntrboot` folder on your flashcart's MicroSD card
+1. Download the [ntrboot flasher](/assets/files/ntrboot_flasher_nds.nds) and copy it to anywhere on your flashcart's MicroSD card
+1. Insert the MicroSD card into the flashcart and boot the flashcart on the working console
+1. Launch `ntrboot_flasher_nds.nds` from your flashcart's kernel
+1. Follow the instructions on screen. Select your cartridge from the list, back up your flashcard with the `Dump Flash` option, then inject ntrboot. You must select the "TWL" option
+
+{% endcapture tab-unhacked %}
+{% assign tab-unhacked = tab-unhacked | split: "////////" %}
 
 {% capture tab-dsi %}
 
@@ -27,7 +44,7 @@ You must have already followed [dsi.cfw.guide](https://dsi.cfw.guide) and have a
 1. Download the [ntrboot image](/assets/files/default.gcd) to your DSi SD card as `sdmc:/ntrboot/default.gcd`
 1. Download the [ntrboot flasher](/assets/files/ntrboot_flasher_nds.nds) to anywhere on your SD card
 1. Insert your SD card into a modded DSi, then run the ntrboot flasher
-1. Follow the instructions on screen. Select your cartridge from the list, back up your flashcard, then inject ntrboot. You must select the "TWL" option
+1. Follow the instructions on screen. Select your cartridge from the list, back up your flashcard with the `Dump Flash` option, then inject ntrboot. You must select the "TWL" option
 
 {% endcapture tab-dsi %}
 {% assign tab-dsi = tab-dsi | split: "////////" %}
@@ -40,25 +57,31 @@ You must have already followed [3ds.hacks.guide](https://3ds.hacks.guide) and ha
 
 1. Download the [ntrboot image](/assets/files/default.gcd) to your 3DS SD card as `sdmc:/ntrboot/default.gcd`
 1. Download the [ntrboot flasher](/assets/files/ntrboot_flasher.firm) to your SD card as `sdmc:/luma/payloads/ntrboot_flasher.firm`
-1. Insert your SD card into a modded 3DS. Hold `START` to open the luma chainloader, then select the ntrboot flasher
-1. Follow the instructions on screen. Select your cartridge from the list, back up your flashcard, then inject ntrboot. You must select the "TWL" option
+1. Insert your SD card into a modded 3DS. Power on your 3DS while holding `START` to open the luma chainloader, then select the ntrboot flasher
+1. Follow the instructions on screen. Select your cartridge from the list, back up your flashcard with the `Dump Flash` option, then inject ntrboot. You must select the "TWL" option
 
 {% endcapture tab-3ds %}
 {% assign tab-3ds = tab-3ds | split: "////////" %}
 
 ### Flashing ntrboot
-{% assign tabs = tab-dsi | concat: tab-3ds %}
+{% assign tabs = tab-unhacked | concat: tab-dsi | concat: tab-3ds %}
 {% include tabs.html index=0 tabs=tabs %}
 
 ### Running ntrboot
 
-1. Download any homebrew to the SD card as `sdmc:/ntrboot.nds`. For this example we'll use [GodMode9i](https://github.com/DS-Homebrew/GodMode9i/releases/).
+1. Download any homebrew to the **DSi** SD card (not the flashcart MicroSD card) as `sdmc:/ntrboot.nds`. For this example we'll use [GodMode9i](https://github.com/DS-Homebrew/GodMode9i/releases/).
 1. Insert your SD card and the ntrboot flashcard in your DSi
 1. Place a magnet near the `ABXY` buttons until you trigger sleep mode
 1. Turn off your DSi
 1. With the magnet in place, hold `start` + `select` + `x` and turn the DSi on
 1. GodMode9i should now boot
 
+### Troubleshooting
+
 If ntrboot does nothing and you're sure that the magnet and button combo are correct, ntrboot might not be working. Try following the flashing instructions again with [this ntrboot image](/assets/files/default_green.gcd) and see if ntrboot loads a green screen. If it does not, your flashcard may be incompatible and you will need to ask in the [DS(i) Mode Hacking](https://ds-homebrew.com/discord) Discord server.
 
 If you get a "NAND Init failure" error or don't see the NAND from ntrboot, you will need to boot the homebrew you want through another program (eg. launching SafeNANDManager through GodMode9i). There is an issue with ntrboot in which the CID/ConsoleID are not properly set up on boot, so mounting the NAND for editing/recovery will not work right away.
+
+### Removing ntrboot
+
+If you wish to restore your flashcart back to it's original state before it was flashed with ntrboot, read the section on [removing ntrboot](/ds-index/removing-ntrboot).

--- a/pages/_en-US/ds-index/removing-ntrboot.md
+++ b/pages/_en-US/ds-index/removing-ntrboot.md
@@ -1,0 +1,59 @@
+---
+lang: en-US
+layout: wiki
+section: ds-index
+category: guides
+title: Removing ntrboot
+description: How to remove ntrboot and restore a flashcart
+tabs:
+  - dsi: DSi
+    3ds: 3DS
+---
+
+Once a flashcart has been flashed with **ntrboot** it is typically no longer usable as a DS flashcart (with the exception of certain flashcarts such as the Acekard 2i). It is possible to restore a flashrom file back to an ntrboot compatible flashcart to return it to it's previous functionality. If you followed the ntrboot guide, you should have a copy of the flashrom backup.
+
+### Required hardware
+
+To remove ntrboot from your flashcart you will need:
+  - A flashcard that has been flashed with ntrboot
+  - A hacked DSi/3DS running ntrboot flasher in order to restore the flashrom backup to the flashcard
+  - A flashrom backup of your flashcart. If you followed the ntrboot flashing guide, you should have this as a `.bin` file in the `ntrboot` folder from your flashcart MicroSD card or DSi/3DS SD card
+  - If you do **not** have this backup, you may download the corresponding flashrom backup for your flashcart from the [3ds.hacks.guide ntrboot guide](https://3ds.hacks.guide/installing-boot9strap-(ntrboot).html#section-v-removing-ntrboot). These are available as magnet links and require torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download) to download them
+
+{% capture tab-dsi %}
+
+You must have already followed [dsi.cfw.guide](https://dsi.cfw.guide) and have a way of running homebrew.
+{:.alert .alert-warning}
+
+1. Place your flashcart's flashrom backup in the `ntrboot` folder on your DSi SD card. Create this folder if it does not exist
+1. Download the [ntrboot flasher](/assets/files/ntrboot_flasher_nds.nds) to anywhere on your SD card
+1. Insert your SD card into a modded DSi, then run the ntrboot flasher
+1. Follow the instructions on screen. Select your cartridge from the list, then choose the `Restore Flash` option. After the restore has finished, your flashcart should now work as a DS flashcart again
+
+{% endcapture tab-dsi %}
+{% assign tab-dsi = tab-dsi | split: "////////" %}
+
+
+{% capture tab-3ds %}
+
+You must have already followed [3ds.hacks.guide](https://3ds.hacks.guide) and have luma installed
+{:.alert .alert-warning}
+
+1. Place your flashcart's flashrom backup in the `ntrboot` folder on your 3DS SD card. Create this folder if it does not exist.
+1. Download the [ntrboot flasher](/assets/files/ntrboot_flasher.firm) to your SD card as `sdmc:/luma/payloads/ntrboot_flasher.firm`
+1. Insert your SD card into a modded 3DS. Power on your 3DS while holding `START` to open the luma chainloader, then select the ntrboot flasher
+1. Follow the instructions on screen. Select your cartridge from the list, then choose the `Restore Flash` option. After the restore has finished, your flashcart should now work as a DS flashcart again
+
+{% endcapture tab-3ds %}
+{% assign tab-3ds = tab-3ds | split: "////////" %}
+
+### Removing ntrboot
+{% assign tabs = tab-dsi | concat: tab-3ds %}
+{% include tabs.html index=0 tabs=tabs %}
+
+
+### Troubleshooting
+
+In some cases, the restore may fail. This may be due to either an incorrect flashrom backup file, or your flashcard may be incompatible with the restore. ntrboot uses a hardcoded name for restoring flashrom backups. If you renamed the `.bin` file and do not have the original name, you can create a flash dump which will create a `.bin` file of the correct name of which you can then use to rename your flashrom backup.
+
+If you are unsure and require assistance you can ask in the [DS(i) Mode Hacking](https://ds-homebrew.com/discord) Discord server.


### PR DESCRIPTION
- Added a section for flashing ntrboot while booted into a flashcart on a an unmodded/working system.
- Added a page for removing ntrboot to restore the flashcart's functionality.
- Added some extra info about the DS and DS Lite screen types.