### PR TITLE
Update channel structure and links

### DIFF
--- a/pages/_en-US/community/discord-info.md
+++ b/pages/_en-US/community/discord-info.md
@@ -23,29 +23,29 @@ Always remember to check the channel topic and pinned messages before talking in
 **Server Hub**
 - [#announcements][announcements] - Information on new updates to homebrew, as well as general announcements related to the server
 - [#github-updates][github-updates] - Feed of all contributions to and discussions in DS-Homebrew project GitHub repositories
-- [#subreddit-feed][subreddit-feed] - Updates for new posts in the [Subreddit](https://reddit.com/r/NDSBrew)
 - [#community-meta][community-meta] - For giving feedback about the community, including the Discord server, the subreddit, and the [GitHub organization](http://github.com/DS-Homebrew)
 
 **Nintendo DS⁽ⁱ⁾ Modding**
-- [#nds-help][nds-help] - Have an issue with anything Nintendo DS(i) related? Need to ask a general question? Go ahead and do it here, providing all the information you can give (error messages, your console, methods tried, logs, and so forth). Keep 3DS modding in #other-console-modding unless it involves TWL_FIRM
-- [#nds-hardware][nds-hardware] - Place to discuss flashcards, AP patches, and general DS understandings and research. While this channel covers TWL_FIRM on 3DS, please keep 3DS Mode discussions in #other-console-modding
-- [#nds-hacks][nds-hacks] - Talk about ROM hacks, mods, and cheats for Nintendo DS(i) titles. Check the pinned messages for a list of dedicated communities
-- [#nds-dev][nds-dev] - Resources and discussions about DS(i) homebrew development. Regualar discussion of existing homebrew should go in #other-nds-homebrew
+- [#nds-help][nds-help] - Have an issue with anything Nintendo DS(i) related? Need to ask a general question? Go ahead and do it here, providing all the information you can give (error messages, your console, methods tried, logs, and so forth). Keep 3DS modding in [#other-console-modding][other-console-modding] unless it involves TWL_FIRM
+- [#nds-hardware][nds-hardware] - Place to discuss hardmods, and general DS understandings and research. While this channel covers TWL_FIRM on 3DS, please keep 3DS Mode discussions in [#other-console-modding][other-console-modding]
+- [#nds-flashcards][nds-flashcards] - Place to discuss flashcards. Assistance with flashcards belongs in [#⁠nds-help][nds-help]
+- [#nds-game-mods][nds-game-mods] - Talk about ROM hacks, mods, and cheats for Nintendo DS(i) titles. Check the pinned messages for a list of dedicated communities
+- [#nds-dev][nds-dev] - Resources and discussions about DS(i) homebrew development. Regualar discussion of existing homebrew should go in [#other-nds-homebrew][other-nds-homebrew]
 
 **Main DS⁽ⁱ⁾ Homebrew Projects**
-- [#nds-bootstrap-dev][nds-bootstrap-dev] - This channel is for discussion of the development of nds-bootstrap. For help, use #nds-help
-- [#twilight-menu-dev][twilight-menu-dev] - This channel is for discussion of the development of TWiLight Menu++. For help, use #nds-help
-- [#gbarunner3-dev][gbarunner3-dev] - This channel is for discussion of the development of GBARunner3. For help, use #nds-help
+- [#nds-bootstrap-dev][nds-bootstrap-dev] - This channel is for discussion of the development of nds-bootstrap. For help, use [#nds-help][nds-help]
+- [#twilight-menu-dev][twilight-menu-dev] - This channel is for discussion of the development of TWiLight Menu++. For help, use [#nds-help][nds-help]
+- [#gbarunner3-dev][gbarunner3-dev] - This channel is for discussion of the development of GBARunner3. For help, use [#nds-help][nds-help]
 - [#dsi-ntrboot-dev][dsi-ntrboot-dev] - This channel is for discussion of DSi ntrboot development.
 - [#web-dev][web-dev] - Discussion and suggestions for [dsi.cfw.guide](https://dsi.cfw.guide/) and all [DS-Homebrew sites](https://ds-homebrew.com/) go here
 
 **Secondary DS⁽ⁱ⁾ Homebrew Projects**
-- [#godmode9i][godmode9i] - This channel is for discussion of the development of GodMode9i. For help, use #nds-help
-- [#fastvideods][fastvideods] - This channel is for discussion of the development of the FastVideoDS Player and Encoder. For help, use #nds-help
+- [#godmode9i][godmode9i] - This channel is for discussion of the development of GodMode9i. For help, use [#nds-help][nds-help]
+- [#fastvideods][fastvideods] - This channel is for discussion of the development of the FastVideoDS Player and Encoder. For help, use [#nds-help][nds-help]
 - [#other-nds-homebrew][other-nds-homebrew] - This forum is for support, updates, and discussion of Nintendo DS(i) homebrew that isn't covered by other channels. There are threads for individual homebrew applications, and you can make a new one if there isn't already a thread for it
 
 **Community**
-- [#off-topic][off-topic] - A channel for any topic that does not necessarily fit the other channels. Lower-quality posts should be kept to [#shadow-of-server](end-of-server)
+- [#off-topic][off-topic] - A channel for any topic that does not necessarily fit the other channels. Lower-quality posts should be kept to [#shadow-of-server][end-of-server]
 - [#nds-gaming][nds-gaming] - A place to generally discuss games on the DS(i), as well as seek players for online play. Check the pinned messages for a list of dedicated communities
 - [#other-console-modding][other-console-modding] - Talk about homebrew and mods for any other game systems, such as the 3DS when not in TWL_FIRM
 - [#other-dev][other-dev] - Talk about coding and development other than for Nintendo DS
@@ -62,10 +62,10 @@ These roles are given to people that are well trusted to maintain the server. Th
 - Server Maintainers - Help enforce the server rules and manage the server. If there is an issue, contact them first before going higher up
 
 ### User Flair Roles
-These roles can only be given by moderators, and indicate that these users are knowledgeable in those fields, some give access to private channels. If you think that you fit the descriptions for any of these roles, ask in #community-meta. Moderators will evaluate your request based on the role's requirements.
+These roles can only be given by moderators, and indicate that these users are knowledgeable in those fields, some give access to private channels. If you think that you fit the descriptions for any of these roles, ask in [#community-meta][community-meta]. Moderators will evaluate your request based on the role's requirements.
 
 - Developers - This role is given to those who have contributed code to the Nintendo DS scene. If you have any projects for the role, show them in #nds-dev
-- Helpers - This role is given to those that actively provide meaningful assistance in #nds-help or have contributed to compatibility reporting
+- Helpers - This role is given to those that actively provide meaningful assistance in [#nds-help][nds-help] or have contributed to compatibility reporting
     - Helpers have no moderator permissions, please ping a moderator if a situation needs one
 - Nitro Booster - Automatically given to those that have given Server Boosts to the server. This role has no additional permissions, and is not hoisted in the Member List
 
@@ -87,11 +87,11 @@ These roles are only given for very specific purposes by moderators.
 ## Lightning Commands
 Lightning is a Discord bot made by [LightSage](https://github.com/LightSage) which has useful commands for modding communities. The most common command used is `!togglerole`, which will give you any of the following roles below:
 
-- Updates - Get pings for updates on new releases of DS(i) homebrew in #announcements
-- Nintendo DS Online Players - Anyone can ping this role in #nds-gaming when they're looking for people to play DS games online with
+- Updates - Get pings for updates on new releases of DS(i) homebrew in [#announcements][announcements]
+- Nintendo DS Online Players - Anyone can ping this role in [#nds-gaming][nds-gaming] when they're looking for people to play DS games online with
 - Translators - Anyone that wants to be notified for contributing to translations of various DS-Homebrew projects
 
-There are a ton of fun commands you can run as well, but please keep them to [#end-of-server][end-of-server].
+There are a ton of fun commands you can run as well, but please keep them to [#shadow-of-server][end-of-server].
 To learn more, check out their website: <https://lightning.lightsage.dev/>
 
 **Lightning is also used for moderation purposes (to log warns, kicks, mutes, and bans). Keep Direct Messages enabled in the server in case we ever need to reach you.**
@@ -106,32 +106,32 @@ Moderator: @apachethunder, @gericom, @pk11.us
 Minimods: @dartzsoryu, @deletecat, @janni9009, @vikirinox
 
 <!-- Discord channel links -->
-[info-and-rules]: https://discord.com/channels/283769550611152897/626620520330428436
-[useful-resources]: https://discord.com/channels/283769550611152897/638041441079263283
-[member-logs]: https://discord.com/channels/283769550611152897/677714673663082529
+[info-and-rules]: https://discord.com/channels/1289261839804272712/1289261839821176912
+[useful-resources]: https://discord.com/channels/1289261839804272712/1289261840232222760
+[member-logs]: https://discord.com/channels/1289261839804272712/1289261840232222761
 
-[announcements]: https://discord.com/channels/283769550611152897/283771381735489537
-[github-updates]: https://discord.com/channels/283769550611152897/450065134191116290
-[subreddit-feed]: https://discord.com/channels/283769550611152897/869830055377928243
-[community-meta]: https://discord.com/channels/283769550611152897/715651368391671919
+[announcements]: https://discord.com/channels/1289261839804272712/1289263486651863114
+[github-updates]: https://discord.com/channels/1289261839804272712/1289261840450195578
+[community-meta]: https://discord.com/channels/1289261839804272712/1289261840450195579
 
-[nds-help]: https://discord.com/channels/283769550611152897/332961165829210117
-[nds-hardware]: https://discord.com/channels/283769550611152897/547986366357700620
-[nds-hacks]: https://discord.com/channels/283769550611152897/356988919738400768
-[nds-dev]: https://discord.com/channels/283769550611152897/835273459339624499
+[nds-help]: https://discord.com/channels/1289261839804272712/1289261840450195581
+[nds-hardware]: https://discord.com/channels/1289261839804272712/1289261840450195582 
+[nds-flashcards]: https://discord.com/channels/1289261839804272712/1298426889215414302
+[nds-game-mods]: https://discord.com/channels/1289261839804272712/1289261840450195583
+[nds-dev]: https://discord.com/channels/1289261839804272712/1289261840450195584
 
-[nds-bootstrap-dev]: https://discord.com/channels/283769550611152897/283769550611152897
-[twilight-menu-dev]: https://discord.com/channels/283769550611152897/489307733074640926
-[gbarunner3-dev]: https://discord.com/channels/283769550611152897/620310871800807466
-[dsi-ntrboot-dev]: https://discord.com/channels/283769550611152897/1193678677666431097
-[web-dev]: https://discord.com/channels/283769550611152897/744649302567157800
+[nds-bootstrap-dev]: https://discord.com/channels/1289261839804272712/1289261840450195586
+[twilight-menu-dev]: https://discord.com/channels/1289261839804272712/1289261840450195587
+[gbarunner3-dev]: https://discord.com/channels/1289261839804272712/1289261840613900370
+[dsi-ntrboot-dev]: https://discord.com/channels/1289261839804272712/1289261840613900371
+[web-dev]: https://discord.com/channels/1289261839804272712/1289261840613900372
 
-[godmode9i]: https://discord.com/channels/283769550611152897/497960894660083732
-[fastvideods]: https://discord.com/channels/283769550611152897/1021121766585806989
-[other-nds-homebrew]: https://discord.com/channels/283769550611152897/1025388133388394547
+[godmode9i]: https://discord.com/channels/1289261839804272712/1289261840613900374
+[fastvideods]: https://discord.com/channels/1289261839804272712/1289261840613900375
+[other-nds-homebrew]: https://discord.com/channels/1289261839804272712/1289263357802844240
 
-[off-topic]: https://discord.com/channels/283769550611152897/286686210225864725
-[nds-gaming]: https://discord.com/channels/283769550611152897/668680785154408448
-[other-console-modding]: https://discord.com/channels/283769550611152897/653706029736919051
-[other-dev]: https://discord.com/channels/283769550611152897/1169696607294468177
-[end-of-server]: https://discord.com/channels/283769550611152897/283770736215195648
+[off-topic]: https://discord.com/channels/1289261839804272712/1289261840613900377
+[nds-gaming]: https://discord.com/channels/1289261839804272712/1289261840613900378
+[other-console-modding]: https://discord.com/channels/1289261839804272712/1289261840613900379
+[other-dev]: https://discord.com/channels/1289261839804272712/1289261840815231047
+[end-of-server]: https://discord.com/channels/1289261839804272712/1289261840815231048


### PR DESCRIPTION
All of the channel links have been dead ever since the move to the new server. 
The subreddit feed no longer exists, nds-hacks was renamed to nds-game-mods, and the nds-flashcards channel was added. 
This PR updates the channel structure and links to reflect these changes.