### PR TITLE
Modify GBA BIOS Dumper save file size check

### DIFF
--- a/assets/js/bios-shrinker.js
+++ b/assets/js/bios-shrinker.js
@@ -2,8 +2,8 @@ const gbaSha = "fd2547724b505f487e6dcb29ec2ecff3af35a841a77ab2e85fd87350abd36570
 const dsSha = "782eb3894237ec6aa411b78ffee19078bacf10413856d33cda10b44fd9c2856b";
 
 function shrinkBios(file) {
-    // Check that the file is 32 KiB
-    if(file.size != 32 << 10)
+    // Check that the file is 32 KiB or more
+    if(file.size < 32 << 10)
         return alert("Error! This is not a correct GBA BIOS dumper save.");
 
     // Read the file


### PR DESCRIPTION
Many flashcards will automatically set the save file of GBA BIOS Dumper to 64 KiB. This is an issue as the trim tool on the wiki only accounts for the save file being 32KiB, not more nor less.

I've changed the check so that it's only looking to see if the file is less than 32KiB. With the save file from my EZODE (64KiB), it seems to work fine now.