### PR TITLE
Update nftr-editor URL

### DIFF
--- a/pages/_en-US/twilightmenu/custom-fonts.md
+++ b/pages/_en-US/twilightmenu/custom-fonts.md
@@ -20,7 +20,7 @@ You may add fonts to [custom DSi/3DS themes](custom-dsi-3ds-themes), which will 
 Custom themes can additionally use override fonts for the date & time using `date_time.nftr`, and the console username with `username.nftr`.
 
 ### Generating custom fonts
-You can make your own fonts using a utility such as Pk11's [nftr-editor](https://web.archive.org/web/20240618221756/https://pk11.us/nftr-editor/). To regenerate one of TWiLight Menu++'s existing fonts using it:
+You can make your own fonts using a utility such as Pk11's [nftr-editor](https://pk11.sh/nftr-editor/). To regenerate one of TWiLight Menu++'s existing fonts using it:
 1. Load an NFTR file in nftr-editor
 1. Type the names of the fonts you want to use from highest to lowest priority in the `Input font` text box, comma separated
     - You can see a preview of the input fonts in the top box on the left and the current NFTR in the bottom box


### PR DESCRIPTION
nftr-editor is now being hosted at https://pk11.sh/nftr-editor - the archive link is no longer needed.